### PR TITLE
feat: add media streaming from telegram

### DIFF
--- a/TelegramDownloader/Controllers/FileController.cs
+++ b/TelegramDownloader/Controllers/FileController.cs
@@ -9,13 +9,16 @@ using Syncfusion.Blazor.FileManager;
 using Syncfusion.Blazor.Inputs;
 using Syncfusion.EJ2.FileManager.Base;
 using Syncfusion.EJ2.FileManager.PhysicalFileProvider;
+using Syncfusion.EJ2.Notifications;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Web;
 using System.Xml.Linq;
 using TelegramDownloader.Data;
 using TelegramDownloader.Data.db;
@@ -234,7 +237,7 @@ namespace TelegramDownloader.Controllers
         }
 
         [Route("GetFile/{id}")]
-        public async Task<IActionResult> GetFile(string id, string? idChannel, string? idFile )
+        public async Task<IActionResult> GetFile(string id, string? idChannel, string? idFile)
         {
             var fileName = id;
             var mimeType = FileService.getMimeType(id.Split(".").Last());
@@ -242,7 +245,7 @@ namespace TelegramDownloader.Controllers
             if ( file == null )
             {
                 // HttpResponseMessage fullResponse = new HttpResponseMessage(HttpStatusCode.OK); // Request.CreateResponse(HttpStatusCode.OK);
-                Message idM = await _ts.getMessageFile(idChannel, Convert.ToInt32(idFile));
+                TL.Message idM = await _ts.getMessageFile(idChannel, Convert.ToInt32(idFile));
                 ChatMessages cm = new ChatMessages();
                 cm.message = idM;
                 file = new FileStream(System.IO.Path.Combine(FileService.TEMPDIR, "_temp", $"{idChannel}-{idFile}-{id}"), FileMode.Create, FileAccess.ReadWrite);
@@ -253,6 +256,8 @@ namespace TelegramDownloader.Controllers
                 await _ts.DownloadFileAndReturn(cm, file, model: dm);
                 file.Position = 0; 
             }
+            var request = HttpContext.Request;
+            var rangeHeader = request.Headers["Range"].ToString();
 
             return new FileStreamResult(file, mimeType)
             {
@@ -260,6 +265,231 @@ namespace TelegramDownloader.Controllers
                 EnableRangeProcessing = true
                 
             };
+        }
+
+        [Route("GetFileStream/{idChannel}/{idFile}/{name}")]
+        public async Task<IActionResult> GetFileStream(string idChannel, string idFile, string name)
+        {
+            var fileName = name;
+            var mimeType = FileService.getMimeType(name.Split(".").Last());
+
+            var request = HttpContext.Request;
+            var rangeHeader = request.Headers["Range"].ToString();
+
+            var file = await _fs.getItemById(idChannel, idFile);
+
+            TL.Message idM = await _ts.getMessageFile(idChannel, file.MessageId ?? file.ListMessageId.FirstOrDefault());
+
+            long totalLength = 0; // (await _fs.getItemById(idChannel, idFile)).Size;
+
+            if(idM.media is MessageMediaDocument { document: Document document })
+            {
+                totalLength = document.size;
+            }
+
+            long from = 0;
+            long initialFrom = 0;
+            long to = 0;
+
+            if (!string.IsNullOrEmpty(rangeHeader) && rangeHeader.StartsWith("bytes="))
+            {
+                var range = rangeHeader.Replace("bytes=", "").Split('-');
+                from = long.Parse(range[0]);
+                initialFrom = from;
+                if (range.Length > 1 && !string.IsNullOrEmpty(range[1]))
+                    to = long.Parse(range[1]);
+            }
+
+            if (from > 0)
+            {
+                from = (from / 524288) * 524288;
+            }
+
+            Console.WriteLine("Fom:" + from);
+
+            if (to == 0)
+                if (string.IsNullOrEmpty(rangeHeader) || from == 0)
+                    to = (12 * 524288) + from;
+                else
+                    to = (5 * 524288) + from;
+            else
+                    to = ((to + 524288) / 524288) * 524288;
+
+            if (to > totalLength)
+            {
+                to = totalLength;
+            }
+
+            if (totalLength == initialFrom)
+            {
+                Response.StatusCode = 416; // Range Not Satisfiable
+                Response.Headers["Content-Range"] = $"bytes */{totalLength}";
+                return new EmptyResult();
+            }
+
+            long length = to - from;
+            //Console.WriteLine("To length: " + to);
+            //Console.WriteLine("future download length: " + length);
+
+            byte[] data = await _ts.DownloadFileStream(idM, from, (int)length);
+
+            //Console.WriteLine("Total download length: " + data.Length);
+
+            long skipedBytes = initialFrom - from - (length - data.Length);
+
+            if (skipedBytes < 0) skipedBytes = 0;
+
+            if (skipedBytes > data.Length)
+                return StatusCode(500, "No hay suficientes bytes en el bloque descargado");
+
+            long dataLength = data.Length - skipedBytes;
+            Response.ContentLength = dataLength; //(dataLength + initialFrom) >= totalLength ? totalLength - initialFrom : dataLength;
+            // Response.StatusCode = (int)HttpStatusCode.PartialContent; // 206
+            Response.StatusCode = StatusCodes.Status206PartialContent; // StatusCodes.Status206PartialContent;
+            Response.ContentType = mimeType;
+            Response.Headers["Content-Disposition"] = $"inline; filename=\"{HttpUtility.UrlEncode(fileName)}\"";
+            Response.Headers.Add("Content-Range", $"bytes {(initialFrom >= totalLength ? totalLength - 1 : initialFrom)}-{(initialFrom >= totalLength ? totalLength - 1 : initialFrom + Response.ContentLength - 1)}/{totalLength}");
+            Response.Headers.Add("Accept-Ranges", "bytes");
+
+            //if (Request.Headers.ContainsKey("Range"))
+            //{
+            //    Console.WriteLine("Range header recibido:");
+            //    Console.WriteLine(Request.Headers["Range"]);
+            //}
+
+            //foreach (var header in Response.Headers)
+            //{
+            //    Console.WriteLine($"{header.Key}: {header.Value}");
+            //}
+
+
+            // Console.WriteLine("Skiped bytes: " + skipedBytes);
+
+            var stream = new MemoryStream(data, (int)skipedBytes, (int)Response.ContentLength);
+            stream.Position = 0;
+
+            //  Console.WriteLine("Real Data length: " + stream.Length);
+
+            // Console.WriteLine("---------------------------------------------------");
+
+            var cancellationToken = HttpContext.RequestAborted;
+
+            try
+            {
+                await stream.CopyToAsync(Response.Body, 64 * 1024, cancellationToken);
+                await Response.Body.FlushAsync(cancellationToken);
+
+                return new EmptyResult();
+            }
+            catch (OperationCanceledException)
+            {
+                Console.WriteLine("❌ El cliente cerró la conexión.");
+            }
+
+            return new EmptyResult();
+
+        }
+
+        [Route("GetFileStream2/{idChannel}/{idFile}/{name}")]
+        public async Task<IActionResult> GetFileStream2(string idChannel, string idFile, string name)
+        {
+            var fileName = name;
+            var mimeType = FileService.getMimeType(name.Split(".").Last());
+
+            var request = HttpContext.Request;
+            var rangeHeader = request.Headers["Range"].ToString();
+
+            var file = await _fs.getItemById(idChannel, idFile);
+
+            // HttpResponseMessage fullResponse = new HttpResponseMessage(HttpStatusCode.OK); // Request.CreateResponse(HttpStatusCode.OK);
+            TL.Message idM = await _ts.getMessageFile(idChannel, file.MessageId ?? file.ListMessageId.FirstOrDefault());
+            //byte[] data = await _ts.DownloadFileStream(idM, 0, 512);
+            //var stream = new MemoryStream(data);
+
+            // Supón que puedes obtener el tamaño total del archivo remoto
+            long totalLength = (await _fs.getItemById(idChannel, idFile)).Size;
+
+            long from = 0;
+            long initialFrom = 0;
+            long to = 0;
+
+
+
+            if (!string.IsNullOrEmpty(rangeHeader) && rangeHeader.StartsWith("bytes="))
+            {
+                var range = rangeHeader.Replace("bytes=", "").Split('-');
+                from = long.Parse(range[0]);
+                initialFrom = from;
+                if (range.Length > 1 && !string.IsNullOrEmpty(range[1]))
+                    to = long.Parse(range[1]);
+            }
+
+            if (from > 0)
+            {
+                from = (from / 524288) * 524288;
+            }
+
+            if (to == 0)
+                to = (25 * 524288) + from;
+            else
+                to = ((to + 524288) / 524288) * 524288;
+
+            if (to > totalLength)
+            {
+                to = totalLength - 1;
+            }
+
+            long length = to - from;
+
+            byte[] data = await _ts.DownloadFileStream(idM, from, (int)length);
+
+            long skipedBytes = initialFrom - from; // (data.Length + initialFrom) >= totalLength ? data.Length - (totalLength - initialFrom) : initialFrom - from;
+
+            if (skipedBytes < 0) skipedBytes = 0;
+
+            if (skipedBytes >= data.Length)
+                return StatusCode(500, "No hay suficientes bytes en el bloque descargado");
+
+            long dataLength = data.Length - skipedBytes;
+            Response.ContentLength = (dataLength + initialFrom) >= totalLength ? totalLength - initialFrom : dataLength;
+            // Response.StatusCode = (int)HttpStatusCode.PartialContent; // 206
+            Response.StatusCode = StatusCodes.Status206PartialContent;
+            Response.ContentType = mimeType;
+            Response.Headers.Add("Content-Range", $"bytes {initialFrom}-{(initialFrom + Response.ContentLength - 1)}/{totalLength}");
+            Response.Headers.Add("Accept-Ranges", "bytes");
+
+            if (Request.Headers.ContainsKey("Range"))
+            {
+                Console.WriteLine("Range header recibido:");
+                Console.WriteLine(Request.Headers["Range"]);
+            }
+
+            foreach (var header in Response.Headers)
+            {
+                Console.WriteLine($"{header.Key}: {header.Value}");
+            }
+
+
+
+
+            var stream = new MemoryStream(data, (int)skipedBytes, (int)Response.ContentLength);
+
+            Console.WriteLine("Real Data length: " + stream.Length);
+
+            Console.WriteLine("---------------------------------------------------");
+
+            //return new FileStreamResult(stream, mimeType);
+            var cancellationToken = HttpContext.RequestAborted;
+
+            await stream.CopyToAsync(Response.Body, 64 * 1024, cancellationToken);
+            await Response.Body.FlushAsync(cancellationToken);
+
+            return new EmptyResult();
+            // return File(stream, mimeType, enableRangeProcessing: false);
+            //return new FileStreamResult(stream, mimeType)
+            //{
+            //    EnableRangeProcessing = false
+            //};
 
         }
 

--- a/TelegramDownloader/Data/FileService.cs
+++ b/TelegramDownloader/Data/FileService.cs
@@ -117,7 +117,7 @@ namespace TelegramDownloader.Data
     {"mid", "audio/midi"},
     {"midi", "audio/midi"},
     {"mif", "application/vnd.mif"},
-    {"mkv", "video/webm" },
+    {"mkv", "video/x-matroska" },
     {"mov", "video/quicktime"},
     {"movie", "video/x-sgi-movie"},
     {"mp2", "audio/mpeg"},

--- a/TelegramDownloader/Data/ITelegramService.cs
+++ b/TelegramDownloader/Data/ITelegramService.cs
@@ -17,6 +17,7 @@ namespace TelegramDownloader.Data
         Task joinChatInvitationHash(string? hash);
         Task<User> CallQrGenerator(Action<string> func, CancellationToken ct, bool logoutFirst = false);
         Task<string> DownloadFile(ChatMessages message, string fileName = null, string folder = null, DownloadModel model = null, bool shouldAddToList = false);
+        Task<Byte[]> DownloadFileStream(Message message, long offset, int limit);
         Task<Stream> DownloadFileAndReturn(ChatMessages message, Stream ms = null, string fileName = null, string folder = null, DownloadModel model = null);
         Task<List<ChatViewBase>> GetFouriteChannels(bool mustRefresh = true);
         Task AddFavouriteChannel(long id);

--- a/TelegramDownloader/Data/TelegramService.cs
+++ b/TelegramDownloader/Data/TelegramService.cs
@@ -1,11 +1,19 @@
 ﻿using BlazorBootstrap;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Syncfusion.Blazor.Inputs;
+using Syncfusion.Blazor.Kanban.Internal;
+using Syncfusion.Blazor.Sparkline.Internal;
 using System.Collections.Generic;
+using System.Reflection.Metadata;
 using System.Threading.Tasks;
 using TelegramDownloader.Data.db;
 using TelegramDownloader.Models;
 using TelegramDownloader.Services;
 using TL;
+using TL.Layer23;
+using TL.Methods;
+using WTelegram;
 
 namespace TelegramDownloader.Data
 {
@@ -13,6 +21,7 @@ namespace TelegramDownloader.Data
     {
         public static bool isPremium = false;
         public static int splitSizeGB = 2;
+        private const int FILESPLITSIZE = 524288; // 512 * 1024;
         private TransactionInfoService _tis { get; set; }
         private IDbService _db { get; set; }
         private static WTelegram.Client client = null;
@@ -335,7 +344,7 @@ namespace TelegramDownloader.Data
                         ChatMessages cm2 = new ChatMessages();
                         cm2.message = msg;
                         cm2.isDocument = false;
-                        if (msg.media is MessageMediaDocument { document: Document document })
+                        if (msg.media is MessageMediaDocument { document: TL.Document document })
                         {
                             cm2.isDocument = true;
                         }
@@ -374,7 +383,7 @@ namespace TelegramDownloader.Data
                     ChatMessages cm2 = new ChatMessages();
                     cm2.message = msg;
                     cm2.isDocument = false;
-                    if (msg.media is MessageMediaDocument { document: Document document })
+                    if (msg.media is MessageMediaDocument { document: TL.Document document })
                     {
                         cm2.isDocument = true;
                     }
@@ -435,7 +444,7 @@ namespace TelegramDownloader.Data
                     ChatMessages cm2 = new ChatMessages();
                     cm2.message = msg;
                     cm2.isDocument = false;
-                    if (msg.media is MessageMediaDocument { document: Document document })
+                    if (msg.media is MessageMediaDocument { document: TL.Document document })
                     {
                         cm2.isDocument = true;
                     }
@@ -471,7 +480,7 @@ namespace TelegramDownloader.Data
                     ChatMessages cm2 = new ChatMessages();
                     cm2.message = msg;
                     cm2.isDocument = false;
-                    if (msg.media is MessageMediaDocument { document: Document document })
+                    if (msg.media is MessageMediaDocument { document: TL.Document document })
                     {
                         cm2.isDocument = true;
                     }
@@ -511,7 +520,7 @@ namespace TelegramDownloader.Data
 
                         cm2.user = messages.UserOrChat(msg.From ?? msg.Peer);
                         cm2.isDocument = false;
-                        if (msg.media is MessageMediaDocument { document: Document document })
+                        if (msg.media is MessageMediaDocument { document: TL.Document document })
                         {
                             cm2.isDocument = true;
                         }
@@ -547,7 +556,7 @@ namespace TelegramDownloader.Data
 
                     cm2.user = mess.UserOrChat(mb.From ?? mb.Peer);
                     cm2.isDocument = false;
-                    if (msg.media is MessageMediaDocument { document: Document document })
+                    if (msg.media is MessageMediaDocument { document: TL.Document document })
                     {
                         cm2.isDocument = true;
                     }
@@ -601,6 +610,84 @@ namespace TelegramDownloader.Data
                 await GetFouriteChannels();
             }
         }
+        public async Task<Byte[]> DownloadFileStream(Message message, long offset, int limit)
+        {
+            int totalLimit = limit;
+            long currentOffset = offset;
+            Byte[] response;
+            if (message is Message msg && msg.media is MessageMediaDocument doc)
+            {
+                try
+                {
+                    using (var memoryStream = new MemoryStream())
+                    {
+                        while (totalLimit > 0)
+                        {
+                            int totalDownloadBytes = FILESPLITSIZE;
+                            if (totalLimit >= FILESPLITSIZE)
+                            {
+                                totalDownloadBytes = FILESPLITSIZE;
+                               
+                            }
+                            //else if (totalLimit >= 4096)
+                            //{
+                            //    // Busca el mayor múltiplo de 4096 menor o igual a totalLimit
+                            //    totalDownloadBytes = (totalLimit / 4096) * 4096;
+                            //}
+                            else
+                            {
+                                // Último trozo, menor de 4096
+                                totalDownloadBytes = FILESPLITSIZE; // totalLimit;
+                                //totalDownloadBytes = totalLimit;
+                            }
+
+                            InputDocument inputFile = doc.document;
+                            var location = new InputDocumentFileLocation
+                            {
+                                id = inputFile.id,
+                                access_hash = inputFile.access_hash,
+                                file_reference = inputFile.file_reference,
+                                thumb_size = ""
+                            };
+
+                            //var file = await client.Invoke(new Upload_GetFile
+                            //{
+                            //    location = new InputDocumentFileLocation
+                            //    {
+                            //        id = inputFile.id,
+                            //        access_hash = inputFile.access_hash,
+                            //        file_reference = inputFile.file_reference,
+                            //        thumb_size = ""
+                            //    },
+                            //    offset = currentOffset,
+                            //    limit = totalDownloadBytes
+                            //});
+
+                            var file = await client.Upload_GetFile(location, currentOffset, limit: totalDownloadBytes);
+
+                            if (file is Upload_File uploadFile)
+                            {
+                                //uploadFile.WriteTL(new BinaryWriter(memoryStream));
+                                var fileBytes = uploadFile.bytes;
+                                memoryStream.Write(fileBytes, 0, fileBytes.Length);
+                                currentOffset += (totalDownloadBytes);
+                                totalLimit -= (totalDownloadBytes);
+                                continue;
+                            }
+                            throw new InvalidOperationException("Unexpected file type returned.");
+                        }
+
+                        return memoryStream.ToArray();
+                    }
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException("Unexpected file type returned.");
+                }
+            }
+                
+            throw new ArgumentException("Invalid message or media type.");
+        }
 
         public async Task<Stream> DownloadFileAndReturn(ChatMessages message, Stream ms = null, string fileName = null, string folder = null, DownloadModel model = null)
         {
@@ -613,7 +700,7 @@ namespace TelegramDownloader.Data
             model.m = message;
             model.channel = message.user;
 
-            if (message.message.media is MessageMediaDocument { document: Document document })
+            if (message.message.media is MessageMediaDocument { document: TL.Document document })
             {
 
                 model._transmitted = 0;
@@ -628,6 +715,7 @@ namespace TelegramDownloader.Data
                 MemoryStream dest = new MemoryStream();
                 // using var dest = new FileStream($"{Path.Combine(folder != null ? folder : Path.Combine(Environment.CurrentDirectory, "download"), filename)}", FileMode.Create, FileAccess.Write);
                 await client.DownloadFileAsync(document, ms ?? dest, null, model.ProgressCallback);
+                   
                 return ms ?? dest;
                 // fileStream.CopyTo(dest);
                 Console.WriteLine("Download finished");
@@ -640,7 +728,7 @@ namespace TelegramDownloader.Data
                 Console.WriteLine("Downloading " + filename);
                 MemoryStream dest = new MemoryStream();
                 // using var dest = new FileStream($"{Path.Combine(Environment.CurrentDirectory!, "wwwroot", "img", "telegram", filename)}", FileMode.Create, FileAccess.Write);
-                var type = await client.DownloadFileAsync(photo, ms ?? dest, null, model.ProgressCallback);
+                var type = await client.DownloadFileAsync(photo, ms ?? dest, (PhotoSizeBase)null, model.ProgressCallback);
                 dest.Close(); // necessary for the renaming
                 Console.WriteLine("Download finished");
                 //if (type is not Storage_FileType.unknown and not Storage_FileType.partial)
@@ -666,7 +754,7 @@ namespace TelegramDownloader.Data
             model.m = message;
             model.channel = message.user;
 
-            if (message.message.media is MessageMediaDocument { document: Document document })
+            if (message.message.media is MessageMediaDocument { document: TL.Document document })
             {
 
                 model._transmitted = 0;

--- a/TelegramDownloader/Data/db/DbService.cs
+++ b/TelegramDownloader/Data/db/DbService.cs
@@ -333,7 +333,7 @@ namespace TelegramDownloader.Data.db
         {
             if (collectionName == null)
                 collectionName = "directory";
-            var result = await (await getDatabase(dbName).GetCollection<BsonFileManagerModel>(collectionName).FindAsync(Builders<BsonFileManagerModel>.Filter.Where(x => x.FilePath + "/" == path || x.FilterPath == path))).ToListAsync();
+            var result = await (await getDatabase(dbName).GetCollection<BsonFileManagerModel>(collectionName).FindAsync(Builders<BsonFileManagerModel>.Filter.Where(x => x.FilterId == path || x.FilePath + "/" == path || x.FilterPath == path))).ToListAsync();
             return result;
         }
 

--- a/TelegramDownloader/Pages/Partials/impl/FileManagerImpl.razor
+++ b/TelegramDownloader/Pages/Partials/impl/FileManagerImpl.razor
@@ -6,6 +6,8 @@
 @using TelegramDownloader.Data
 @using TelegramDownloader.Data.db
 @using TelegramDownloader.Models
+@using TelegramDownloader.Pages.Modals.InfoModals
+@using TelegramDownloader.Pages.Modals
 @using TelegramDownloader.Pages.Partials
 @inject IFileService fs
 @inject ITelegramService ts
@@ -18,18 +20,18 @@
 
 
     <FileManagerEvents TValue="FileManagerDirectoryContent"
-                       ToolbarItemClicked="toolBarClicked"
-                       ItemsMoving="ItemsMovingAsync"
-                       ItemRenaming="ItemRenamingAsync"
-                       Searching="SearchingAsync"
-                       OnFileOpen="FileOpen"
-                       FileSelection="FileSelectionAsync"
-                       FileSelected="FileSelectedAsync"
-                       OnRead="OnReadAsync"
-                       FolderCreating="FolderCreatingAsync"
-                       BeforeDownload="BeforeDownload"
-                       ItemsDeleting="ItemsDeletingAsync"
-                       ItemsUploaded="ItemsUploadedAsync"></FileManagerEvents>
+    ToolbarItemClicked="toolBarClicked"
+    ItemsMoving="ItemsMovingAsync"
+    ItemRenaming="ItemRenamingAsync"
+    Searching="SearchingAsync"
+    OnFileOpen="fileOpen"
+    FileSelection="FileSelectionAsync"
+    FileSelected="FileSelectedAsync"
+    OnRead="OnReadAsync"
+    FolderCreating="FolderCreatingAsync"
+    BeforeDownload="BeforeDownload"
+    ItemsDeleting="ItemsDeletingAsync"
+    ItemsUploaded="ItemsUploadedAsync"></FileManagerEvents>
     <FileManagerUploadSettings MaxFileSize="@(long.MaxValue)" AutoUpload="true"></FileManagerUploadSettings>
     <FileManagerToolbarSettings ToolbarItems="@Items"></FileManagerToolbarSettings>
     <FileManagerContextMenuSettings Visible="@(!isShared)" File="@ContextItems"></FileManagerContextMenuSettings>
@@ -37,6 +39,8 @@
 </SfFileManager>
 <TelegramDownloader.Pages.Modals.DowloadFromTelegram @ref="Modal" isShare="@isShared" bsi="@bsi"></TelegramDownloader.Pages.Modals.DowloadFromTelegram>
 
+<TelegramDownloader.Pages.Modals.InfoModals.MediaUrlModal @ref="mediaUrlModal"></TelegramDownloader.Pages.Modals.InfoModals.MediaUrlModal>
+<TelegramDownloader.Pages.Modals.VideoPlayerModal @ref="videoPlayer"></TelegramDownloader.Pages.Modals.VideoPlayerModal>
 
 
 
@@ -53,6 +57,9 @@
     public static string[] selectedItems = new string[] { "" };
     public static bool downloadToServer = true;
     LocalFileManager lfm { get; set; }
+    private VideoPlayerModal videoPlayer { get; set; } = default!;
+
+    private MediaUrlModal mediaUrlModal { get; set; } = default!;
 
     public string[] ContextItems = new string[] { "Open", "Delete", "Download", "Rename", "Details"};
 
@@ -68,6 +75,8 @@
         new ToolBarItemModel() { Name = "Selection" },
         new ToolBarItemModel() { Name = "View" },
         new ToolBarItemModel() { Name = "Details" },
+        new ToolBarItemModel() { Name = "UrlMedia", Text = "Url Media", TooltipText = "Url Media", PrefixIcon = "bi bi-collection-play-fill", Visible = false }
+
     };
 
     // protected override async Task OnParametersSetAsync()
@@ -80,6 +89,7 @@
     {
 
     }
+
 
     protected override async Task OnInitializedAsync()
     {
@@ -121,23 +131,24 @@
         // args.Response = await FileManagerService.Rename(args.Path, args.File.Name, args.NewName, false, args.ShowFileExtension, args.File);
     }
 
-    public async Task FileOpen(FileOpenEventArgs<FileManagerDirectoryContent> args)
+    public async Task fileOpen(FileOpenEventArgs<FileManagerDirectoryContent> args)
     {
-        if (!isShared && args != null && args.FileDetails != null && args.FileDetails.IsFile && new List<string> { ".mp3", ".ogg", ".flac", ".aac", ".wav" }.Contains(args.FileDetails.Type.ToLower()))
+        if (args != null && args.FileDetails != null && args.FileDetails.IsFile && new List<string> { ".mp3", ".ogg", ".flac", ".aac", ".wav" }.Contains(args.FileDetails.Type.ToLower()))
         {
             await playAudio(args);
-            // string localdir = "/" + FileService.STATICRELATIVELOCALDIR.Replace("\\", "/");
-            // string path = Path.Combine(localdir, args.FileDetails.FilterPath.Substring(1).Replace("\\", "/"), args.FileDetails.Name);
-            // await JSRuntime.InvokeVoidAsync("open", path, "_blank");
+        }
+        else
+        {
+            if (args != null && args.FileDetails != null && args.FileDetails.IsFile && new List<string> { ".mov", ".mp4", ".m4v", ".ogv", ".webm", ".flv", ".f4v" }.Contains(args.FileDetails.Type.ToLower()))
+            {
+                videoPlayer.ShowModal(getMediaUrl(args.FileDetails.Id, args.FileDetails.Name));
+            }
         }
     }
 
     private async Task playAudio(FileOpenEventArgs<FileManagerDirectoryContent> args)
     {
-        var file = await fs.getItemById(id, args.FileDetails.Id);
-        string path = MyNavigationManager.BaseUri + "api/file/getfile/" + args.FileDetails.Name + $"?idChannel={id}&idFile={file.MessageId}";
-        // string path = new System.Uri((Path.Combine(localdir, args.FileDetails.FilterPath.Substring(1).Replace("\\", "/"), args.FileDetails.Name)).Replace("\\", "/")).AbsoluteUri;
-        await JSRuntime.InvokeVoidAsync("openAudioPlayerModal", path, FileService.getMimeType(args.FileDetails.Name.Split(".").Last()), args.FileDetails.Name);
+        await JSRuntime.InvokeVoidAsync("openAudioPlayerModal", getMediaUrl(args.FileDetails.Id, args.FileDetails.Name), null, args.FileDetails.Name);
     }
 
     public async Task SearchingAsync(SearchEventArgs<FileManagerDirectoryContent> args)
@@ -188,6 +199,18 @@
         Console.WriteLine("");
     }
 
+    private async Task ShowMediaURLModal(string idFile, String name)
+    {
+        mediaUrlModal.url = getMediaUrl(idFile, name);
+        await mediaUrlModal.OnShowModalClick();
+    }
+
+    private string getMediaUrl(string idFile, String name)
+    {
+        string localdir = MyNavigationManager.BaseUri;
+        return new System.Uri(Path.Combine(localdir, "api/file/GetFileStream", id, idFile, name).Replace("\\", "/")).AbsoluteUri;
+    }
+
     public async Task toolBarClicked(ToolbarClickEventArgs<FileManagerDirectoryContent> args)
     {
         if (args.Item.Text == "Download To Local")
@@ -206,6 +229,10 @@
         if (args.Item.Text == "Share File")
         {
             MyNavigationManager.NavigateTo("/api/file/share/" + id + $"?bsonId={args.FileDetails.FirstOrDefault().Id}&fileName={args.FileDetails.FirstOrDefault().Name}", true);
+        }
+        if (args.Item.Text == "Url Media" && args.FileDetails.Count() > 0)
+        {
+            await ShowMediaURLModal(args.FileDetails[0].Id, args.FileDetails[0].Name);
         }
         Console.WriteLine("");
     }
@@ -226,7 +253,17 @@
 
     public async Task FileSelectionAsync(FileSelectionEventArgs<FileManagerDirectoryContent> args)
     {
-        Console.WriteLine("");
+        List<FileManagerDirectoryContent> selectedList = fm.GetSelectedFiles();
+        if ((selectedList.Count() + (args.Action == "UnSelect" ? -1 : 1)) == 1)
+        {
+            if (args.FileDetails.IsFile)
+            {
+                Items.Where(x => x.Name == "UrlMedia").FirstOrDefault().Visible = true;
+                return;
+            }
+
+        }
+        Items.Where(x => x.Name == "UrlMedia").FirstOrDefault().Visible = false;
     }
 
     public async Task FileSelectedAsync(FileSelectEventArgs<FileManagerDirectoryContent> args)

--- a/TelegramDownloader/TelegramDownloader.csproj
+++ b/TelegramDownloader/TelegramDownloader.csproj
@@ -13,15 +13,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazor.Bootstrap" Version="3.3.1" />
+    <PackageReference Include="Blazor.Bootstrap" Version="3.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="8.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="3.3.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.4.0" />
     <PackageReference Include="QRCoder" Version="1.6.0" />
-    <PackageReference Include="Syncfusion.Blazor" Version="29.1.39" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
-    <PackageReference Include="Syncfusion.EJ2.AspNet.Core" Version="29.1.39" />
-    <PackageReference Include="System.IO.Hashing" Version="9.0.4" />
-    <PackageReference Include="WTelegramClient" Version="4.3.3" />
+    <PackageReference Include="Syncfusion.Blazor" Version="29.2.11" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Syncfusion.EJ2.AspNet.Core" Version="29.2.11" />
+    <PackageReference Include="System.IO.Hashing" Version="9.0.7" />
+    <PackageReference Include="WTelegramClient" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #30 

Add media streaming from remote storage.

It plays audio and video in the following formats:

Audio: ".mp3", ".ogg", ".flac", ".aac", ".wav"
Video: ".mov", ".mp4", ".m4v", ".ogv", ".webm", ".flv", ".f4v"

You also have the option to copy the media URL so you can play it in an external player such as MPV.

PS: VLC desktop has a problem and isn't playing correctly.