### PR TITLE
feat: wire progressive download cache into tfm streaming endpoint

### DIFF
--- a/TelegramDownloader/Controllers/Mobile/MobileStreamController.cs
+++ b/TelegramDownloader/Controllers/Mobile/MobileStreamController.cs
@@ -26,6 +26,13 @@ namespace TelegramDownloader.Controllers.Mobile
         private readonly ILogger<MobileStreamController> _logger;
         private static readonly SemaphoreSlim _downloadSemaphore = new(5); // Allow 5 concurrent downloads for preload
 
+        // Limit concurrent direct range fetches against Telegram (seeks ahead of the cache)
+        private static readonly SemaphoreSlim _telegramRangeSemaphore = new(4);
+
+        // If the requested range starts within this distance of the background download
+        // position, wait for the download instead of opening a duplicate Telegram fetch
+        private const long WAIT_PROXIMITY_BYTES = 4 * 1024 * 1024;
+
         public MobileStreamController(
             ITelegramService ts,
             IDbService db,
@@ -238,28 +245,43 @@ namespace TelegramDownloader.Controllers.Mobile
                     }
                 }
 
-                // Parse range header
+                // Parse range header (RFC 7233: bytes=X-, bytes=X-Y, bytes=-N)
                 var rangeHeader = Request.Headers["Range"].ToString();
+                long totalLength = dbFile.Size;
                 long from = 0;
-                long to = 0;
+                long? to = null;
                 bool hasRange = false;
 
-                if (!string.IsNullOrEmpty(rangeHeader) && rangeHeader.StartsWith("bytes="))
+                if (!string.IsNullOrEmpty(rangeHeader) && rangeHeader.StartsWith("bytes=") && !rangeHeader.Contains(','))
                 {
-                    hasRange = true;
-                    var range = rangeHeader.Replace("bytes=", "").Split('-');
-                    from = long.Parse(range[0]);
-                    if (range.Length > 1 && !string.IsNullOrEmpty(range[1]))
-                        to = long.Parse(range[1]);
+                    var parts = rangeHeader.Substring("bytes=".Length).Split('-');
+                    if (parts.Length == 2)
+                    {
+                        if (string.IsNullOrEmpty(parts[0]))
+                        {
+                            // Suffix range: last N bytes
+                            if (long.TryParse(parts[1], out var suffixLength) && suffixLength > 0)
+                            {
+                                from = Math.Max(0, totalLength - suffixLength);
+                                to = totalLength - 1;
+                                hasRange = true;
+                            }
+                        }
+                        else if (long.TryParse(parts[0], out var parsedFrom) && parsedFrom >= 0)
+                        {
+                            from = parsedFrom;
+                            hasRange = true;
+                            if (!string.IsNullOrEmpty(parts[1]) && long.TryParse(parts[1], out var parsedTo))
+                                to = parsedTo;
+                        }
+                    }
+                    // Malformed ranges fall through as "no range" (initial chunk)
                 }
 
-                long totalLength = dbFile.Size;
-
-                // Check how much is already cached
-                long cachedBytes = 0;
-                if (System.IO.File.Exists(filePath))
+                if (hasRange && (from >= totalLength || (to.HasValue && to.Value < from)))
                 {
-                    cachedBytes = new FileInfo(filePath).Length;
+                    Response.Headers["Content-Range"] = $"bytes */{totalLength}";
+                    return StatusCode(StatusCodes.Status416RangeNotSatisfiable);
                 }
 
                 // For initial request without Range, return first chunk as 206 with full size info
@@ -270,23 +292,59 @@ namespace TelegramDownloader.Controllers.Mobile
                     to = Math.Min(2 * 1024 * 1024, totalLength - 1); // First 2MB
                 }
 
-                // Handle Range request
-                if (to == 0 || to >= totalLength)
+                // Open-ended or oversized ranges: cap the response to ~2.5MB
+                long rangeEnd = (!to.HasValue || to.Value >= totalLength)
+                    ? Math.Min(from + (5 * 524288), totalLength - 1)
+                    : to.Value;
+
+                // Kick off (or attach to) the background download that fills the disk cache,
+                // so every streamed track ends up cached and is downloaded from Telegram once
+                ProgressiveDownloadInfo downloadInfo = null;
+                if (dbFile.MessageId.HasValue)
                 {
-                    // Open-ended range
-                    to = Math.Min(from + (5 * 524288), totalLength - 1); // ~2.5MB chunk
+                    try
+                    {
+                        downloadInfo = await _progressiveDownload.StartOrGetDownloadAsync(cacheFileName, channelId, dbFile, filePath);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Could not start background cache download for {FileName}", name);
+                    }
                 }
 
-                // Check if range is available locally
+                long CachedBytes()
+                {
+                    long onDisk = System.IO.File.Exists(filePath) ? new FileInfo(filePath).Length : 0;
+                    return Math.Max(onDisk, downloadInfo?.DownloadedBytes ?? 0);
+                }
+
+                // If the background download is nearby, wait briefly for it to cover the
+                // range start instead of opening a duplicate Telegram download. This is the
+                // normal sequential-playback path: same latency as a direct fetch (both pull
+                // sequential 512KB chunks), but the bytes get persisted.
+                if (downloadInfo != null && downloadInfo.IsDownloading &&
+                    from - CachedBytes() <= WAIT_PROXIMITY_BYTES)
+                {
+                    var waitTarget = Math.Min(rangeEnd, from + 524288); // at least 512KB past the start
+                    var deadline = DateTime.UtcNow.AddSeconds(12);
+                    while (downloadInfo.IsDownloading &&
+                           downloadInfo.DownloadedBytes <= waitTarget &&
+                           DateTime.UtcNow < deadline)
+                    {
+                        await Task.Delay(150, HttpContext.RequestAborted);
+                    }
+                }
+
+                var cachedBytes = CachedBytes();
+
+                // Serve from the (possibly still growing) cache file
                 if (from < cachedBytes)
                 {
-                    // Part or all of range is in cache
-                    var availableEnd = Math.Min(to, cachedBytes - 1);
+                    var availableEnd = Math.Min(rangeEnd, cachedBytes - 1);
                     var length = availableEnd - from + 1;
 
                     _logger.LogDebug("Serving from cache: bytes {From}-{To} of {Total}", from, availableEnd, totalLength);
 
-                    // Read from cache file
                     using var cacheStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                     cacheStream.Seek(from, SeekOrigin.Begin);
                     var buffer = new byte[length];
@@ -303,10 +361,10 @@ namespace TelegramDownloader.Controllers.Mobile
                     return new EmptyResult();
                 }
 
-                // Range not in cache - stream from Telegram
-                _logger.LogDebug("Streaming from Telegram: bytes {From}-{To} of {Total}", from, to, totalLength);
+                // Range far ahead of the background download (seek): fetch it directly from
+                // Telegram, streaming each 512KB chunk to the response as it arrives
+                _logger.LogDebug("Streaming from Telegram: bytes {From}-{To} of {Total}", from, rangeEnd, totalLength);
 
-                // Get message from Telegram
                 if (!dbFile.MessageId.HasValue)
                 {
                     return NotFound(ApiResponse<object>.Fail("File has no MessageId"));
@@ -318,34 +376,52 @@ namespace TelegramDownloader.Controllers.Mobile
                     return NotFound(ApiResponse<object>.Fail("Message not found in Telegram"));
                 }
 
-                // Align to 512KB boundaries for Telegram
+                // Align down to 512KB for Telegram; skip the prefix when writing the response
                 var alignedFrom = (from / 524288) * 524288;
-                var alignedTo = ((to + 524288) / 524288) * 524288;
-                if (alignedTo > totalLength) alignedTo = totalLength;
-
-                var downloadLength = alignedTo - alignedFrom;
-
-                // Download the range from Telegram
-                byte[] data = await _ts.DownloadFileStream(message, alignedFrom, (int)downloadLength);
-
-                // Calculate skip bytes to get to the exact requested position
                 var skipBytes = from - alignedFrom;
-                var responseLength = Math.Min(to - from + 1, data.Length - skipBytes);
+                var responseLength = rangeEnd - from + 1;
 
-                if (skipBytes < 0 || skipBytes >= data.Length)
+                await _telegramRangeSemaphore.WaitAsync(HttpContext.RequestAborted);
+                try
                 {
-                    _logger.LogError("Invalid skip calculation: skipBytes={Skip}, dataLength={DataLen}", skipBytes, data.Length);
-                    return StatusCode(500, "Error calculating response range");
+                    Response.StatusCode = StatusCodes.Status206PartialContent;
+                    Response.ContentType = mimeType;
+                    Response.ContentLength = responseLength;
+                    Response.Headers["Content-Range"] = $"bytes {from}-{rangeEnd}/{totalLength}";
+                    Response.Headers["Accept-Ranges"] = "bytes";
+                    Response.Headers["Content-Disposition"] = $"inline; filename=\"{HttpUtility.UrlEncode(name)}\"";
+
+                    long remainingSkip = skipBytes;
+                    long remainingWrite = responseLength;
+
+                    await foreach (var chunk in _ts.DownloadFileStreamChunks(
+                        message, alignedFrom, skipBytes + responseLength, HttpContext.RequestAborted))
+                    {
+                        int start = 0;
+                        int length = chunk.Length;
+
+                        if (remainingSkip > 0)
+                        {
+                            var toSkip = (int)Math.Min(remainingSkip, length);
+                            start += toSkip;
+                            length -= toSkip;
+                            remainingSkip -= toSkip;
+                        }
+
+                        if (length <= 0) continue;
+
+                        var toWrite = (int)Math.Min(length, remainingWrite);
+                        await Response.Body.WriteAsync(chunk, start, toWrite, HttpContext.RequestAborted);
+                        remainingWrite -= toWrite;
+
+                        if (remainingWrite <= 0) break;
+                    }
+                }
+                finally
+                {
+                    _telegramRangeSemaphore.Release();
                 }
 
-                Response.StatusCode = StatusCodes.Status206PartialContent;
-                Response.ContentType = mimeType;
-                Response.ContentLength = responseLength;
-                Response.Headers["Content-Range"] = $"bytes {from}-{from + responseLength - 1}/{totalLength}";
-                Response.Headers["Accept-Ranges"] = "bytes";
-                Response.Headers["Content-Disposition"] = $"inline; filename=\"{HttpUtility.UrlEncode(name)}\"";
-
-                await Response.Body.WriteAsync(data, (int)skipBytes, (int)responseLength);
                 return new EmptyResult();
             }
             catch (OperationCanceledException)

--- a/TelegramDownloader/Data/ITelegramService.cs
+++ b/TelegramDownloader/Data/ITelegramService.cs
@@ -21,6 +21,7 @@ namespace TelegramDownloader.Data
         Task<User> CallQrGenerator(Action<string> func, CancellationToken ct, bool logoutFirst = false);
         Task<string> DownloadFile(ChatMessages message, string fileName = null, string folder = null, DownloadModel model = null, bool shouldAddToList = false);
         Task<Byte[]> DownloadFileStream(Message message, long offset, int limit);
+        IAsyncEnumerable<byte[]> DownloadFileStreamChunks(Message message, long offset, long limit, CancellationToken ct = default);
         Task<Stream> DownloadFileAndReturn(ChatMessages message, Stream ms = null, string fileName = null, string folder = null, DownloadModel model = null);
         Task<Stream> DownloadFileAndReturnWithOffset(ChatMessages message, Stream ms = null, string fileName = null, string folder = null, DownloadModel model = null, long offset = 0);
         Task<List<ChatViewBase>> GetFouriteChannels(bool mustRefresh = true);

--- a/TelegramDownloader/Data/TelegramService.cs
+++ b/TelegramDownloader/Data/TelegramService.cs
@@ -8,6 +8,7 @@ using Syncfusion.Blazor.Schedule;
 using Syncfusion.Blazor.Sparkline.Internal;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using TelegramDownloader.Data.db;
@@ -1124,6 +1125,62 @@ namespace TelegramDownloader.Data
             }
 
             throw new ArgumentException("Invalid message or media type.");
+        }
+
+        /// <summary>
+        /// Streams a byte range from Telegram in 512KB chunks, yielding each chunk as it
+        /// arrives instead of buffering the whole range in memory. Offset must be 4KB-aligned
+        /// (callers align to 512KB). Stops early if Telegram signals end of file.
+        /// </summary>
+        public async IAsyncEnumerable<byte[]> DownloadFileStreamChunks(Message message, long offset, long limit, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            _logger.LogDebug("DownloadFileStreamChunks - Offset: {Offset}, Limit: {Limit}", offset, limit);
+
+            if (message is not Message msg || msg.media is not MessageMediaDocument doc)
+                throw new ArgumentException("Invalid message or media type.");
+
+            InputDocument inputFile = doc.document;
+            long currentOffset = offset;
+            long remaining = limit;
+
+            while (remaining > 0)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var location = new InputDocumentFileLocation
+                {
+                    id = inputFile.id,
+                    access_hash = inputFile.access_hash,
+                    file_reference = inputFile.file_reference,
+                    thumb_size = ""
+                };
+
+                Upload_FileBase file;
+                try
+                {
+                    file = await client.Upload_GetFile(location, currentOffset, limit: FILESPLITSIZE);
+                }
+                catch (RpcException ex) when (ex.Code == 303 && ex.Message == "FILE_MIGRATE_X")
+                {
+                    var dcClient = await client.GetClientForDC(-ex.X, true);
+                    file = await dcClient.Upload_GetFile(location, currentOffset, limit: FILESPLITSIZE);
+                }
+
+                if (file is not Upload_File uploadFile)
+                    throw new InvalidOperationException("Unexpected file type returned.");
+
+                if (uploadFile.bytes.Length == 0)
+                    yield break;
+
+                yield return uploadFile.bytes;
+
+                currentOffset += uploadFile.bytes.Length;
+                remaining -= uploadFile.bytes.Length;
+
+                // Telegram returns fewer bytes than requested only at end of file
+                if (uploadFile.bytes.Length < FILESPLITSIZE)
+                    yield break;
+            }
         }
 
         public async Task<Stream> DownloadFileAndReturn(ChatMessages message, Stream ms = null, string fileName = null, string folder = null, DownloadModel model = null)

--- a/TelegramDownloader/Services/ProgressiveDownloadService.cs
+++ b/TelegramDownloader/Services/ProgressiveDownloadService.cs
@@ -60,6 +60,11 @@ namespace TelegramDownloader.Services
         // Lock for starting downloads
         private readonly ConcurrentDictionary<string, SemaphoreSlim> _downloadLocks = new();
 
+        // Cache directory size cap: oldest files are evicted first (by write time)
+        private const long MAX_CACHE_BYTES = 10L * 1024 * 1024 * 1024; // 10 GB
+        private static DateTime _lastCleanup = DateTime.MinValue;
+        private static readonly object _cleanupLock = new();
+
         public ProgressiveDownloadService(
             ITelegramService ts,
             TransactionInfoService tis,
@@ -89,12 +94,6 @@ namespace TelegramDownloader.Services
         {
             if (!_activeDownloads.TryGetValue(cacheKey, out var info))
             {
-                // Check if file exists and is complete
-                if (File.Exists(info?.FilePath ?? ""))
-                {
-                    var fileInfo = new FileInfo(info!.FilePath);
-                    return end <= fileInfo.Length;
-                }
                 return false;
             }
 
@@ -111,7 +110,12 @@ namespace TelegramDownloader.Services
             // Quick check if already complete
             if (_activeDownloads.TryGetValue(cacheKey, out var existingInfo) && existingInfo.IsComplete)
             {
-                return existingInfo;
+                if (File.Exists(existingInfo.FilePath))
+                {
+                    return existingInfo;
+                }
+                // Cache file was evicted: forget the stale entry and re-download
+                _activeDownloads.TryRemove(cacheKey, out _);
             }
 
             // Check if file already exists and is complete
@@ -143,7 +147,8 @@ namespace TelegramDownloader.Services
                 // Double-check after acquiring lock
                 if (_activeDownloads.TryGetValue(cacheKey, out existingInfo))
                 {
-                    if (existingInfo.IsComplete || existingInfo.IsDownloading)
+                    if (existingInfo.IsDownloading ||
+                        (existingInfo.IsComplete && File.Exists(existingInfo.FilePath)))
                     {
                         return existingInfo;
                     }
@@ -234,7 +239,9 @@ namespace TelegramDownloader.Services
 
                 // Download in chunks
                 const int chunkSize = 512 * 1024; // 512KB chunks
+                const int maxConsecutiveErrors = 5;
                 var chatMessage = new ChatMessages { message = message };
+                var consecutiveErrors = 0;
 
                 while (info.DownloadedBytes < info.TotalSize && !info.CancellationTokenSource!.Token.IsCancellationRequested)
                 {
@@ -255,6 +262,7 @@ namespace TelegramDownloader.Services
 
                         info.DownloadedBytes += chunk.Length;
                         dm._transmitted = info.DownloadedBytes;
+                        consecutiveErrors = 0;
 
                         // Log progress every 10%
                         var progress = (double)info.DownloadedBytes / info.TotalSize * 100;
@@ -266,9 +274,19 @@ namespace TelegramDownloader.Services
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
-                        _logger.LogError(ex, "Error downloading chunk at offset {Offset}", info.DownloadedBytes);
-                        // Wait a bit and retry
-                        await Task.Delay(1000);
+                        consecutiveErrors++;
+                        _logger.LogError(ex, "Error downloading chunk at offset {Offset} (attempt {Attempt}/{Max})",
+                            info.DownloadedBytes, consecutiveErrors, maxConsecutiveErrors);
+
+                        if (consecutiveErrors >= maxConsecutiveErrors)
+                        {
+                            _logger.LogError("Aborting background download after {Max} consecutive failures: {CacheKey}",
+                                maxConsecutiveErrors, info.CacheKey);
+                            break;
+                        }
+
+                        // Back off progressively before retrying
+                        await Task.Delay(1000 * consecutiveErrors);
                     }
                 }
 
@@ -280,6 +298,11 @@ namespace TelegramDownloader.Services
                     Path.GetFileName(info.FilePath),
                     info.DownloadedBytes,
                     info.TotalSize);
+
+                if (info.IsComplete && !string.IsNullOrEmpty(directory))
+                {
+                    _ = Task.Run(() => TrimCacheDirectory(directory));
+                }
             }
             catch (OperationCanceledException)
             {
@@ -290,6 +313,68 @@ namespace TelegramDownloader.Services
             {
                 _logger.LogError(ex, "Error in background download: {CacheKey}", info.CacheKey);
                 info.IsDownloading = false;
+            }
+        }
+
+        /// <summary>
+        /// Keeps the streaming cache directory under MAX_CACHE_BYTES, deleting the
+        /// oldest files first (by write time). Files being downloaded are skipped.
+        /// Throttled to run at most every 30 minutes.
+        /// </summary>
+        private void TrimCacheDirectory(string directory)
+        {
+            lock (_cleanupLock)
+            {
+                if (DateTime.UtcNow - _lastCleanup < TimeSpan.FromMinutes(30)) return;
+                _lastCleanup = DateTime.UtcNow;
+            }
+
+            try
+            {
+                var files = new DirectoryInfo(directory).GetFiles();
+                var totalSize = files.Sum(f => f.Length);
+                if (totalSize <= MAX_CACHE_BYTES) return;
+
+                var activePaths = _activeDownloads.Values
+                    .Where(i => i.IsDownloading)
+                    .Select(i => i.FilePath)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+                var removed = 0;
+                foreach (var file in files.OrderBy(f => f.LastWriteTimeUtc))
+                {
+                    if (totalSize <= MAX_CACHE_BYTES) break;
+                    if (activePaths.Contains(file.FullName)) continue;
+
+                    try
+                    {
+                        var size = file.Length;
+                        file.Delete();
+                        totalSize -= size;
+                        removed++;
+
+                        // Drop any stale tracking entry pointing at the deleted file
+                        var stale = _activeDownloads.FirstOrDefault(kv =>
+                            string.Equals(kv.Value.FilePath, file.FullName, StringComparison.OrdinalIgnoreCase));
+                        if (stale.Key != null)
+                        {
+                            _activeDownloads.TryRemove(stale.Key, out _);
+                        }
+                    }
+                    catch (IOException)
+                    {
+                        // File in use (e.g. being served): skip it
+                    }
+                }
+
+                if (removed > 0)
+                {
+                    _logger.LogInformation("Cache trim: removed {Count} files from {Directory}", removed, directory);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Cache trim failed for {Directory}", directory);
             }
         }
     }


### PR DESCRIPTION
## Summary

The `/api/mobile/stream/tfm` endpoint downloaded every uncached Range request from Telegram and discarded the bytes, so consecutive requests (and the TFM Audio PWA background cache) re-downloaded the same data repeatedly. The `ProgressiveDownloadService` that solves this existed and was injected into the controller, but was never invoked.

## Changes

**MobileStreamController (`tfm` endpoint)**
- Starts (or attaches to) the background `ProgressiveDownloadService` download on each request, so every streamed track is fetched from Telegram exactly once and persisted to the disk cache.
- Serves ranges from the growing cache file; when the background download is within 4MB of the requested start, waits briefly (max 12s) for it instead of opening a duplicate Telegram fetch. Sequential playback latency is unchanged (both paths pull sequential 512KB chunks).
- Far-ahead seeks still fetch directly from Telegram, now streaming each 512KB chunk to the response as it arrives (no more 2.5MB in-memory buffering) and limited to 4 concurrent fetches by a semaphore.
- Robust Range parsing: `TryParse` instead of `Parse` (malformed headers no longer 500), suffix ranges (`bytes=-N`), `416 Range Not Satisfiable` with `Content-Range: bytes */total`, and the ambiguous `to == 0` sentinel replaced by `long?`.

**TelegramService**
- New `DownloadFileStreamChunks` (`IAsyncEnumerable<byte[]>`): yields 512KB chunks from `upload.getFile` as they arrive, with `FILE_MIGRATE_X` handling and cancellation support.

**ProgressiveDownloadService**
- Fixed `IsRangeAvailable` null-check bug (dead branch checking `info?.FilePath` after a failed `TryGetValue`).
- Stale complete entries whose cache file was deleted are dropped and re-downloaded instead of serving a missing file.
- Chunk retry loop capped at 5 consecutive failures with progressive backoff (previously retried forever).
- Cache directory trimmed to 10GB after each completed download (oldest files first by write time, skips active downloads, throttled to every 30 minutes).

## Test plan

- [ ] Play an uncached track from the PWA: logs show `Starting background download`, then `Serving from cache: bytes ...` for subsequent Range requests.
- [ ] Replay the same track: `Serving fully cached file`.
- [ ] Seek far ahead right after starting: single `Streaming from Telegram` direct fetch, playback continues.
- [ ] Malformed/suffix Range headers return 206/416 instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)