### PR TITLE
feat: configurable STRM streaming mode with progressive disk cache

### DIFF
--- a/TelegramDownloader/Controllers/FileController.cs
+++ b/TelegramDownloader/Controllers/FileController.cs
@@ -31,13 +31,22 @@ namespace TelegramDownloader.Controllers
         string root = FileService.RELATIVELOCALDIR;
 
         private static SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1);
+
+        // Limit concurrent direct range fetches against Telegram (seeks ahead of the cache)
+        private static readonly SemaphoreSlim telegramRangeSemaphore = new SemaphoreSlim(4);
+
+        // If the requested range starts within this distance of the background download
+        // position, wait for the download instead of opening a duplicate Telegram fetch
+        private const long WAIT_PROXIMITY_BYTES = 8 * 1024 * 1024;
+
         IDbService _db { get; set; }
         ITelegramService _ts { get; set; }
         IFileService _fs { get; set; }
         TransactionInfoService _tis { get; set; }
+        private readonly IProgressiveDownloadService _progressiveDownload;
         private ILogger<IFileService> _logger { get; set; }
 
-        public FileController(IDbService db, ITelegramService ts, IFileService fs, TransactionInfoService tis, ILogger<IFileService> logger)
+        public FileController(IDbService db, ITelegramService ts, IFileService fs, TransactionInfoService tis, IProgressiveDownloadService progressiveDownload, ILogger<IFileService> logger)
         {
             this.basePath = Environment.CurrentDirectory;
             if (!System.IO.Directory.Exists(Path.Combine(basePath, root)))
@@ -48,6 +57,7 @@ namespace TelegramDownloader.Controllers
             _ts = ts;
             _db = db;
             _tis = tis;
+            _progressiveDownload = progressiveDownload;
             _logger = logger;
             
             this.operation = new PhysicalFileProvider();
@@ -660,6 +670,262 @@ namespace TelegramDownloader.Controllers
 
             return new EmptyResult();
 
+        }
+
+        /// <summary>
+        /// Stream file from Telegram while caching it to disk in the background (progressive streaming).
+        /// Playback starts immediately; once fully cached, ranges are served from disk.
+        /// Supports split (multi-message) files: parts are cached sequentially into a single file
+        /// and seeks ahead of the cache are fetched from the part that contains the requested range.
+        /// </summary>
+        /// <param name="idChannel">Telegram channel ID</param>
+        /// <param name="idFile">TFM database file ID</param>
+        /// <param name="name">File name (used for mime type / Content-Disposition)</param>
+        [HttpGet]
+        [Route("GetFileStreamCached/{idChannel}/{idFile}/{name}")]
+        [ProducesResponseType(typeof(FileStreamResult), 200)]
+        [ProducesResponseType(206)]
+        [ProducesResponseType(404)]
+        [ProducesResponseType(416)]
+        public async Task<IActionResult> GetFileStreamCached(string idChannel, string idFile, string name)
+        {
+            var mimeType = FileService.getMimeType(name.Split(".").Last());
+
+            var dbFile = await _fs.getItemById(idChannel, idFile);
+            if (dbFile == null)
+            {
+                return NotFound();
+            }
+
+            // Ordered Telegram messages that make up the file (several for split files)
+            var messageIds = ProgressiveDownloadService.GetMessageIds(dbFile);
+            if (messageIds == null || messageIds.Count == 0)
+            {
+                return NotFound();
+            }
+
+            var fileName = dbFile.Name;
+            var cacheFileName = $"{idChannel}-{(dbFile.MessageId != null ? dbFile.MessageId.ToString() : dbFile.Id)}-{fileName}";
+            var tempPath = Path.Combine(FileService.TEMPDIR, "_temp");
+            var filePath = Path.Combine(tempPath, cacheFileName);
+            Directory.CreateDirectory(tempPath);
+
+            long totalLength = dbFile.Size;
+
+            // Fully cached: serve straight from disk with full range support
+            if (System.IO.File.Exists(filePath) && new FileInfo(filePath).Length >= totalLength)
+            {
+                _logger.LogDebug("GetFileStreamCached - serving fully cached file {FileName}", fileName);
+                Response.Headers["Content-Disposition"] = $"inline; filename=\"{HttpUtility.UrlEncode(fileName)}\"";
+                return PhysicalFile(filePath, mimeType, enableRangeProcessing: true);
+            }
+
+            // Parse range header (RFC 7233: bytes=X-, bytes=X-Y, bytes=-N)
+            var rangeHeader = Request.Headers["Range"].ToString();
+            long from = 0;
+            long? to = null;
+            bool hasRange = false;
+
+            if (!string.IsNullOrEmpty(rangeHeader) && rangeHeader.StartsWith("bytes=") && !rangeHeader.Contains(','))
+            {
+                var parts = rangeHeader.Substring("bytes=".Length).Split('-');
+                if (parts.Length == 2)
+                {
+                    if (string.IsNullOrEmpty(parts[0]))
+                    {
+                        // Suffix range: last N bytes
+                        if (long.TryParse(parts[1], out var suffixLength) && suffixLength > 0)
+                        {
+                            from = Math.Max(0, totalLength - suffixLength);
+                            to = totalLength - 1;
+                            hasRange = true;
+                        }
+                    }
+                    else if (long.TryParse(parts[0], out var parsedFrom) && parsedFrom >= 0)
+                    {
+                        from = parsedFrom;
+                        hasRange = true;
+                        if (!string.IsNullOrEmpty(parts[1]) && long.TryParse(parts[1], out var parsedTo))
+                            to = parsedTo;
+                    }
+                }
+                // Malformed ranges fall through as "no range" (initial chunk)
+            }
+
+            if (hasRange && (from >= totalLength || (to.HasValue && to.Value < from)))
+            {
+                Response.Headers["Content-Range"] = $"bytes */{totalLength}";
+                return StatusCode(StatusCodes.Status416RangeNotSatisfiable);
+            }
+
+            // Initial request without Range: return the first chunk as 206 with total size info
+            if (!hasRange)
+            {
+                from = 0;
+                to = Math.Min(6 * 1024 * 1024, totalLength - 1);
+            }
+
+            // Open-ended or oversized ranges: cap the response so the player keeps asking
+            long rangeEnd = (!to.HasValue || to.Value >= totalLength)
+                ? Math.Min(from + (4 * 1024 * 1024), totalLength - 1)
+                : to.Value;
+
+            // Kick off (or attach to) the background download that fills the disk cache,
+            // so the file is downloaded from Telegram only once
+            ProgressiveDownloadInfo downloadInfo = null;
+            try
+            {
+                downloadInfo = await _progressiveDownload.StartOrGetDownloadAsync(cacheFileName, idChannel, dbFile, filePath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not start background cache download for {FileName}", fileName);
+            }
+
+            long CachedBytes()
+            {
+                long onDisk = System.IO.File.Exists(filePath) ? new FileInfo(filePath).Length : 0;
+                return Math.Max(onDisk, downloadInfo?.DownloadedBytes ?? 0);
+            }
+
+            try
+            {
+                // If the background download is nearby, wait briefly for it to cover the range
+                // start instead of opening a duplicate Telegram fetch (normal sequential playback)
+                if (downloadInfo != null && downloadInfo.IsDownloading &&
+                    from - CachedBytes() <= WAIT_PROXIMITY_BYTES)
+                {
+                    var waitTarget = Math.Min(rangeEnd, from + 524288); // at least 512KB past the start
+                    var deadline = DateTime.UtcNow.AddSeconds(15);
+                    while (downloadInfo.IsDownloading &&
+                           downloadInfo.DownloadedBytes <= waitTarget &&
+                           DateTime.UtcNow < deadline)
+                    {
+                        await Task.Delay(150, HttpContext.RequestAborted);
+                    }
+                }
+
+                var cachedBytes = CachedBytes();
+
+                // Serve from the (possibly still growing) cache file
+                if (from < cachedBytes)
+                {
+                    var availableEnd = Math.Min(rangeEnd, cachedBytes - 1);
+                    var length = availableEnd - from + 1;
+
+                    _logger.LogDebug("GetFileStreamCached - serving from cache: bytes {From}-{To} of {Total}", from, availableEnd, totalLength);
+
+                    using var cacheStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    cacheStream.Seek(from, SeekOrigin.Begin);
+                    var buffer = new byte[length];
+                    var bytesRead = await cacheStream.ReadAsync(buffer, 0, (int)length, HttpContext.RequestAborted);
+
+                    Response.StatusCode = StatusCodes.Status206PartialContent;
+                    Response.ContentType = mimeType;
+                    Response.ContentLength = bytesRead;
+                    Response.Headers["Content-Range"] = $"bytes {from}-{from + bytesRead - 1}/{totalLength}";
+                    Response.Headers["Accept-Ranges"] = "bytes";
+                    Response.Headers["Content-Disposition"] = $"inline; filename=\"{HttpUtility.UrlEncode(fileName)}\"";
+
+                    await Response.Body.WriteAsync(buffer, 0, bytesRead, HttpContext.RequestAborted);
+                    return new EmptyResult();
+                }
+
+                // Range far ahead of the background download (seek): fetch it directly from
+                // Telegram, streaming each 512KB chunk to the response as it arrives
+                _logger.LogDebug("GetFileStreamCached - streaming from Telegram: bytes {From}-{To} of {Total}", from, rangeEnd, totalLength);
+
+                // Locate the part (Telegram message) containing `from`. Like GetFileStream,
+                // assume uniform part sizes (the splitter uses a fixed split size)
+                TL.Message message;
+                long partStart = 0;
+                long partSize;
+                if (messageIds.Count == 1)
+                {
+                    message = await _ts.getMessageFile(idChannel, messageIds[0]);
+                    partSize = ProgressiveDownloadService.GetDocumentSize(message);
+                }
+                else
+                {
+                    var firstMessage = await _ts.getMessageFile(idChannel, messageIds[0]);
+                    long firstPartSize = ProgressiveDownloadService.GetDocumentSize(firstMessage);
+                    if (firstPartSize <= 0)
+                    {
+                        return NotFound();
+                    }
+                    int partIndex = (int)Math.Min(from / firstPartSize, messageIds.Count - 1);
+                    partStart = (long)partIndex * firstPartSize;
+                    message = partIndex == 0 ? firstMessage : await _ts.getMessageFile(idChannel, messageIds[partIndex]);
+                    partSize = ProgressiveDownloadService.GetDocumentSize(message);
+                }
+
+                if (message == null || partSize <= 0)
+                {
+                    return NotFound();
+                }
+
+                // Serve only up to the end of this part; the player asks for the rest itself
+                rangeEnd = Math.Min(rangeEnd, partStart + partSize - 1);
+                if (rangeEnd < from)
+                {
+                    Response.Headers["Content-Range"] = $"bytes */{totalLength}";
+                    return StatusCode(StatusCodes.Status416RangeNotSatisfiable);
+                }
+
+                // Align down to 512KB for Telegram; skip the prefix when writing the response
+                var localFrom = from - partStart;
+                var alignedFrom = (localFrom / 524288) * 524288;
+                var skipBytes = localFrom - alignedFrom;
+                var responseLength = rangeEnd - from + 1;
+
+                await telegramRangeSemaphore.WaitAsync(HttpContext.RequestAborted);
+                try
+                {
+                    Response.StatusCode = StatusCodes.Status206PartialContent;
+                    Response.ContentType = mimeType;
+                    Response.ContentLength = responseLength;
+                    Response.Headers["Content-Range"] = $"bytes {from}-{rangeEnd}/{totalLength}";
+                    Response.Headers["Accept-Ranges"] = "bytes";
+                    Response.Headers["Content-Disposition"] = $"inline; filename=\"{HttpUtility.UrlEncode(fileName)}\"";
+
+                    long remainingSkip = skipBytes;
+                    long remainingWrite = responseLength;
+
+                    await foreach (var chunk in _ts.DownloadFileStreamChunks(
+                        message, alignedFrom, skipBytes + responseLength, HttpContext.RequestAborted))
+                    {
+                        int start = 0;
+                        int length = chunk.Length;
+
+                        if (remainingSkip > 0)
+                        {
+                            var toSkip = (int)Math.Min(remainingSkip, length);
+                            start += toSkip;
+                            length -= toSkip;
+                            remainingSkip -= toSkip;
+                        }
+
+                        if (length <= 0) continue;
+
+                        var toWrite = (int)Math.Min(length, remainingWrite);
+                        await Response.Body.WriteAsync(chunk, start, toWrite, HttpContext.RequestAborted);
+                        remainingWrite -= toWrite;
+
+                        if (remainingWrite <= 0) break;
+                    }
+                }
+                finally
+                {
+                    telegramRangeSemaphore.Release();
+                }
+
+                return new EmptyResult();
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogDebug("Client closed connection during cached stream - File: {FileName}", fileName);
+                return new EmptyResult();
+            }
         }
 
         /// <summary>

--- a/TelegramDownloader/Data/FileService.cs
+++ b/TelegramDownloader/Data/FileService.cs
@@ -1252,6 +1252,21 @@ namespace TelegramDownloader.Data
             _tis.CheckPendingUploadInfoTasks();
         }
 
+        /// <summary>
+        /// Builds the URL written inside a .strm file according to the configured streaming mode.
+        /// Files smaller than MaxPreloadFileSizeInMb are always fully preloaded.
+        /// </summary>
+        private static string BuildStrmUrl(string host, string dbName, BsonFileManagerModel file)
+        {
+            StreamingMode mode = GeneralConfigStatic.config.GetEffectiveStreamingMode();
+            if (mode == StreamingMode.Preload || HelperService.bytesToMegaBytes(file.Size) < GeneralConfigStatic.config.MaxPreloadFileSizeInMb)
+            {
+                return Path.Combine(host, "api/file/GetFileByTfmId", Uri.EscapeDataString(file.Name)).Replace("\\", "/") + $"?idChannel={dbName}&idFile={file.Id}";
+            }
+            string endpoint = mode == StreamingMode.ProgressiveCache ? "GetFileStreamCached" : "GetFileStream";
+            return Path.Combine(host, "api/file", endpoint, dbName, file.Id, "file" + file.Type).Replace("\\", "/");
+        }
+
         public async Task<String> CreateStrmFiles(string path, string dbName, string host)
         {
             String folderPathName = Path.GetFileName(path.TrimEnd('/'));
@@ -1300,11 +1315,7 @@ namespace TelegramDownloader.Data
                 {
                     if (FileExtensionTypeTest.isVideoExtension(file.Type) || FileExtensionTypeTest.isAudioExtension(file.Type))
                     {
-                        string contenido = Path.Combine(host, "api/file/GetFileStream", dbName, file.Id, "file" + file.Type).Replace("\\", "/");
-                        if (GeneralConfigStatic.config.PreloadFilesOnStream || HelperService.bytesToMegaBytes(file.Size) < GeneralConfigStatic.config.MaxPreloadFileSizeInMb)
-                        {
-                            contenido = Path.Combine(host, "api/file/GetFileByTfmId", Uri.EscapeDataString(file.Name)).Replace("\\", "/") + $"?idChannel={dbName}&idFile={file.Id}";
-                        }
+                        string contenido = BuildStrmUrl(host, dbName, file);
                         string pattern = $@"\.({file.Type.Replace(".", "")})$";
                         File.WriteAllText(Regex.Replace(filePath, pattern, ".strm"), contenido);
                     }
@@ -1338,11 +1349,7 @@ namespace TelegramDownloader.Data
                 {
                     if (FileExtensionTypeTest.isVideoExtension(file.Type) || FileExtensionTypeTest.isAudioExtension(file.Type))
                     {
-                        string contenido = Path.Combine(host, "api/file/GetFileStream", dbName, file.Id, "file" + file.Type).Replace("\\", "/");
-                        if (GeneralConfigStatic.config.PreloadFilesOnStream || HelperService.bytesToMegaBytes(file.Size) < GeneralConfigStatic.config.MaxPreloadFileSizeInMb)
-                        {
-                            contenido = Path.Combine(host, "api/file/GetFileByTfmId", Uri.EscapeDataString(file.Name)).Replace("\\", "/") + $"?idChannel={dbName}&idFile={file.Id}";
-                        }
+                        string contenido = BuildStrmUrl(host, dbName, file);
                         string pattern = $@"\.({file.Type.Replace(".", "")})$";
                         // Ensure parent directory exists
                         var parentDir = Path.GetDirectoryName(Regex.Replace(filePath, pattern, ".strm"));

--- a/TelegramDownloader/Models/GeneralConfig.cs
+++ b/TelegramDownloader/Models/GeneralConfig.cs
@@ -12,6 +12,27 @@ using TelegramDownloader.Services;
 
 namespace TelegramDownloader.Models
 {
+    /// <summary>
+    /// How exported STRM files (Emby/Kodi/etc.) play media from Telegram.
+    /// </summary>
+    public enum StreamingMode
+    {
+        /// <summary>
+        /// Stream chunks directly from Telegram on demand. Playback starts immediately,
+        /// nothing is stored on disk, but every play re-downloads from Telegram.
+        /// </summary>
+        DirectStream = 0,
+        /// <summary>
+        /// Stream immediately while a background download fills the local cache.
+        /// Playback starts from second one and subsequent plays are served from disk.
+        /// </summary>
+        ProgressiveCache = 1,
+        /// <summary>
+        /// Download the whole file to the local cache before playback starts (legacy behavior).
+        /// </summary>
+        Preload = 2
+    }
+
     public class GeneralConfigStatic
     {
         public static GeneralConfig config { get; set; } = new GeneralConfig();
@@ -30,6 +51,10 @@ namespace TelegramDownloader.Models
             int maxAllowedSize = TelegramService.isPremium ? 4 : 2;
             if (gc.MemorySplitSizeGB < 1) gc.MemorySplitSizeGB = 1;
             if (gc.MemorySplitSizeGB > maxAllowedSize) gc.MemorySplitSizeGB = maxAllowedSize;
+
+            // Keep the legacy flag in sync so older builds reading this config behave the same
+            if (gc.StrmStreamingMode.HasValue)
+                gc.PreloadFilesOnStream = gc.StrmStreamingMode.Value == StreamingMode.Preload;
 
             await db.SaveConfig(gc);
             config = gc;
@@ -97,6 +122,19 @@ namespace TelegramDownloader.Models
         public bool ShouldShowCaptionPath { get; set; } = false;
         public bool ShouldShowLogInTerminal { get; set; } = false;
         public bool PreloadFilesOnStream { get; set; } = false;
+        /// <summary>
+        /// Streaming mode used by exported STRM files. Null means "not set yet":
+        /// the effective mode is then derived from the legacy PreloadFilesOnStream flag.
+        /// </summary>
+        [BsonRepresentation(BsonType.String)]
+        public StreamingMode? StrmStreamingMode { get; set; } = null;
+
+        public StreamingMode GetEffectiveStreamingMode()
+        {
+            if (StrmStreamingMode.HasValue)
+                return StrmStreamingMode.Value;
+            return PreloadFilesOnStream ? StreamingMode.Preload : StreamingMode.DirectStream;
+        }
         public bool ShouldShowPaginatedFileChannel { get; set; } = false;
         public bool hasFileManagerVirtualScroll { get; set; } = false;
         public bool UseMobileFileManagerAlways { get; set; } = false;

--- a/TelegramDownloader/Pages/Config.razor
+++ b/TelegramDownloader/Pages/Config.razor
@@ -252,14 +252,24 @@
                         <div class="config-item-info">
                             <div class="config-item-label">
                                 <i class="bi bi-lightning"></i>
-                                Preload Files on Stream
+                                Streaming Mode (STRM / Emby / Kodi)
                             </div>
                             <div class="config-item-description">
-                                Automatically preload files to cache when streaming
+                                How exported .strm files play media from Telegram:
+                                <ul class="mb-0 mt-1" style="padding-left: 1.1rem;">
+                                    <li><strong>Direct streaming:</strong> plays instantly, chunks are fetched from Telegram on demand, nothing is stored on disk. Each play re-downloads from Telegram.</li>
+                                    <li><strong>Progressive cache:</strong> plays instantly while the file is downloaded to the local cache in the background. Next plays are served from disk. <span class="badge bg-success">Recommended</span></li>
+                                    <li><strong>Full preload:</strong> downloads the whole file before playback starts (legacy behavior).</li>
+                                </ul>
+                                <span class="text-muted d-block mt-1">Applies to newly exported STRM files and to playback through the streaming endpoints. Files smaller than "Max. Preload File Size" are always fully preloaded.</span>
                             </div>
                         </div>
                         <div class="config-item-control">
-                            <InputCheckbox @bind-Value="Model!.PreloadFilesOnStream" class="form-check-input config-switch" />
+                            <InputSelect @bind-Value="StreamingModeSetting" class="form-select" style="min-width: 190px;">
+                                <option value="@StreamingMode.DirectStream">Direct streaming</option>
+                                <option value="@StreamingMode.ProgressiveCache">Progressive cache</option>
+                                <option value="@StreamingMode.Preload">Full preload</option>
+                            </InputSelect>
                         </div>
                     </div>
                 </div>
@@ -913,6 +923,23 @@
 
 @code {
     public GeneralConfig Model { get; set; }
+
+    /// <summary>
+    /// Proxy for the STRM streaming mode: reads the effective mode (falling back to the
+    /// legacy PreloadFilesOnStream flag) and keeps that flag in sync when changed.
+    /// </summary>
+    private StreamingMode StreamingModeSetting
+    {
+        get => Model?.GetEffectiveStreamingMode() ?? StreamingMode.DirectStream;
+        set
+        {
+            if (Model != null)
+            {
+                Model.StrmStreamingMode = value;
+                Model.PreloadFilesOnStream = value == StreamingMode.Preload;
+            }
+        }
+    }
     private bool _disposed = false;
     private bool isRestarting = false;
 

--- a/TelegramDownloader/Services/ProgressiveDownloadService.cs
+++ b/TelegramDownloader/Services/ProgressiveDownloadService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using TelegramDownloader.Data;
 using TelegramDownloader.Data.db;
 using TelegramDownloader.Models;
+using TL;
 
 namespace TelegramDownloader.Services
 {
@@ -197,18 +198,12 @@ namespace TelegramDownloader.Services
                     Directory.CreateDirectory(directory);
                 }
 
-                // Get message from Telegram
-                if (!dbFile.MessageId.HasValue)
+                // Ordered list of Telegram messages that make up this file
+                // (split files span several messages, one document per part)
+                var messageIds = GetMessageIds(dbFile);
+                if (messageIds == null || messageIds.Count == 0)
                 {
                     _logger.LogError("File has no MessageId: {CacheKey}", info.CacheKey);
-                    info.IsDownloading = false;
-                    return;
-                }
-
-                var message = await _ts.getMessageFile(channelId, dbFile.MessageId.Value);
-                if (message == null)
-                {
-                    _logger.LogError("Message not found in Telegram: {CacheKey}", info.CacheKey);
                     info.IsDownloading = false;
                     return;
                 }
@@ -220,9 +215,10 @@ namespace TelegramDownloader.Services
                     FileAccess.Write,
                     FileShare.Read);
 
-                // Resume from where we left off if file partially exists
-                var startOffset = fileStream.Length;
-                fileStream.Seek(0, SeekOrigin.End);
+                // Resume from where we left off if file partially exists.
+                // Align down to 512KB so per-part offsets stay Telegram-aligned.
+                var startOffset = (fileStream.Length / 524288) * 524288;
+                fileStream.Seek(startOffset, SeekOrigin.Begin);
                 info.DownloadedBytes = startOffset;
 
                 // Create download model for progress tracking
@@ -237,57 +233,87 @@ namespace TelegramDownloader.Services
                 };
                 _tis.addToDownloadList(dm);
 
-                // Download in chunks
+                // Download in chunks, part by part (a single-message file is just one part)
                 const int chunkSize = 512 * 1024; // 512KB chunks
                 const int maxConsecutiveErrors = 5;
-                var chatMessage = new ChatMessages { message = message };
                 var consecutiveErrors = 0;
+                var aborted = false;
+                long partStartGlobal = 0;
+                var ct = info.CancellationTokenSource!.Token;
 
-                while (info.DownloadedBytes < info.TotalSize && !info.CancellationTokenSource!.Token.IsCancellationRequested)
+                foreach (var msgId in messageIds)
                 {
-                    var remaining = info.TotalSize - info.DownloadedBytes;
-                    var toDownload = (int)Math.Min(chunkSize, remaining);
+                    if (aborted || ct.IsCancellationRequested)
+                        break;
 
-                    try
+                    var message = await _ts.getMessageFile(channelId, msgId);
+                    var partSize = GetDocumentSize(message);
+                    if (message == null || partSize <= 0)
                     {
-                        var chunk = await _ts.DownloadFileStream(message, info.DownloadedBytes, toDownload);
-                        if (chunk.Length == 0)
+                        _logger.LogError("Message {MessageId} not found in Telegram or has no document: {CacheKey}", msgId, info.CacheKey);
+                        aborted = true;
+                        break;
+                    }
+
+                    // Part already fully cached (resume): skip it
+                    if (info.DownloadedBytes >= partStartGlobal + partSize)
+                    {
+                        partStartGlobal += partSize;
+                        continue;
+                    }
+
+                    var localOffset = info.DownloadedBytes - partStartGlobal;
+
+                    while (localOffset < partSize && !ct.IsCancellationRequested)
+                    {
+                        var toDownload = (int)Math.Min(chunkSize, partSize - localOffset);
+
+                        try
                         {
-                            _logger.LogWarning("Received empty chunk at offset {Offset}", info.DownloadedBytes);
-                            break;
+                            var chunk = await _ts.DownloadFileStream(message, localOffset, toDownload);
+                            if (chunk.Length == 0)
+                            {
+                                _logger.LogWarning("Received empty chunk at offset {Offset} of message {MessageId}", localOffset, msgId);
+                                aborted = true;
+                                break;
+                            }
+
+                            await fileStream.WriteAsync(chunk, 0, chunk.Length, ct);
+                            await fileStream.FlushAsync(ct);
+
+                            localOffset += chunk.Length;
+                            info.DownloadedBytes = partStartGlobal + localOffset;
+                            dm._transmitted = info.DownloadedBytes;
+                            consecutiveErrors = 0;
+
+                            // Log progress every 10%
+                            var progress = (double)info.DownloadedBytes / info.TotalSize * 100;
+                            if ((int)progress % 10 == 0)
+                            {
+                                _logger.LogDebug("Download progress: {FileName} - {Progress:F1}%",
+                                    Path.GetFileName(info.FilePath), progress);
+                            }
                         }
-
-                        await fileStream.WriteAsync(chunk, 0, chunk.Length, info.CancellationTokenSource.Token);
-                        await fileStream.FlushAsync(info.CancellationTokenSource.Token);
-
-                        info.DownloadedBytes += chunk.Length;
-                        dm._transmitted = info.DownloadedBytes;
-                        consecutiveErrors = 0;
-
-                        // Log progress every 10%
-                        var progress = (double)info.DownloadedBytes / info.TotalSize * 100;
-                        if ((int)progress % 10 == 0)
+                        catch (Exception ex) when (ex is not OperationCanceledException)
                         {
-                            _logger.LogDebug("Download progress: {FileName} - {Progress:F1}%",
-                                Path.GetFileName(info.FilePath), progress);
+                            consecutiveErrors++;
+                            _logger.LogError(ex, "Error downloading chunk at offset {Offset} of message {MessageId} (attempt {Attempt}/{Max})",
+                                localOffset, msgId, consecutiveErrors, maxConsecutiveErrors);
+
+                            if (consecutiveErrors >= maxConsecutiveErrors)
+                            {
+                                _logger.LogError("Aborting background download after {Max} consecutive failures: {CacheKey}",
+                                    maxConsecutiveErrors, info.CacheKey);
+                                aborted = true;
+                                break;
+                            }
+
+                            // Back off progressively before retrying
+                            await Task.Delay(1000 * consecutiveErrors);
                         }
                     }
-                    catch (Exception ex) when (ex is not OperationCanceledException)
-                    {
-                        consecutiveErrors++;
-                        _logger.LogError(ex, "Error downloading chunk at offset {Offset} (attempt {Attempt}/{Max})",
-                            info.DownloadedBytes, consecutiveErrors, maxConsecutiveErrors);
 
-                        if (consecutiveErrors >= maxConsecutiveErrors)
-                        {
-                            _logger.LogError("Aborting background download after {Max} consecutive failures: {CacheKey}",
-                                maxConsecutiveErrors, info.CacheKey);
-                            break;
-                        }
-
-                        // Back off progressively before retrying
-                        await Task.Delay(1000 * consecutiveErrors);
-                    }
+                    partStartGlobal += partSize;
                 }
 
                 info.IsComplete = info.DownloadedBytes >= info.TotalSize;
@@ -314,6 +340,22 @@ namespace TelegramDownloader.Services
                 _logger.LogError(ex, "Error in background download: {CacheKey}", info.CacheKey);
                 info.IsDownloading = false;
             }
+        }
+
+        /// <summary>
+        /// Ordered list of Telegram message IDs that make up a file: a single message for
+        /// regular files, several (one per part) for split files.
+        /// </summary>
+        internal static List<int>? GetMessageIds(BsonFileManagerModel dbFile)
+        {
+            if (dbFile.MessageId.HasValue && (dbFile.ListMessageId == null || dbFile.ListMessageId.Count <= 1))
+                return new List<int> { dbFile.MessageId.Value };
+            return dbFile.ListMessageId;
+        }
+
+        internal static long GetDocumentSize(Message? message)
+        {
+            return message?.media is MessageMediaDocument { document: Document doc } ? doc.size : 0;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Adds a **Streaming Mode** setting (Configuration → Downloads) that controls how exported STRM files play media from Telegram in Emby/Kodi:

- **Direct streaming** — chunks are fetched from Telegram on demand; playback starts instantly, nothing stored on disk (existing `GetFileStream` endpoint).
- **Progressive cache** *(new, recommended)* — playback starts instantly while a background download fills the local cache; subsequent plays and already-cached ranges are served from disk (new `GetFileStreamCached` endpoint).
- **Full preload** — legacy behavior: the whole file is downloaded before playback (`GetFileByTfmId`).

## Changes

- `GeneralConfig`: new `StreamingMode` enum + `StrmStreamingMode` setting (stored as string in Mongo). Backwards compatible: falls back to the legacy `PreloadFilesOnStream` flag when unset, and keeps that flag in sync on save.
- `FileController`: new `GET /api/File/GetFileStreamCached/{idChannel}/{idFile}/{name}` endpoint with RFC 7233 range parsing, wait-for-nearby-download logic and direct Telegram fetches for seeks ahead of the cache.
- `ProgressiveDownloadService`: now supports **split (multi-message) files** — parts are downloaded sequentially into a single cache file, with resume support and 512KB offset alignment.
- Multi-part seeks: the endpoint locates the Telegram part containing the requested range (uniform part-size assumption, same as `GetFileStream`) and caps each response at the part boundary so players transparently request across parts.
- STRM generation (`CreateStrmFiles` / `CreateStrmFilesToLocal`): shared `BuildStrmUrl` helper picks the endpoint from the configured mode. Files smaller than *Max. Preload File Size* are still always fully preloaded.
- Config page: replaced the *Preload Files on Stream* checkbox with a mode selector including per-mode descriptions.

## Notes

- STRM files must be re-exported after changing the mode (the URL is written inside each `.strm`).
- Progressive cache is trimmed to 10 GB (oldest files first), same as the existing mobile audio cache.

## Test plan

- [x] Build passes with 0 errors
- [ ] Export STRM of a large single-message MKV in Progressive cache mode and play in Kodi/Emby: playback should start in ~1-3s and the file should appear in the `_temp` cache
- [ ] Replay the same file: should be served from disk (no Telegram traffic)
- [ ] Seek beyond the downloaded portion: should play after a short buffering
- [ ] Same checks with a split (multi-part) file, including seeking across part boundaries
- [ ] Verify legacy behavior: setting *Full preload* generates `GetFileByTfmId` URLs
