### PR TITLE
feat: audio transcoding endpoint for offline downloads (MP3/AAC)

### DIFF
--- a/TelegramDownloader/Controllers/Mobile/MobileStreamController.cs
+++ b/TelegramDownloader/Controllers/Mobile/MobileStreamController.cs
@@ -4,6 +4,8 @@ using TelegramDownloader.Data.db;
 using TelegramDownloader.Models;
 using TelegramDownloader.Models.Mobile;
 using TelegramDownloader.Services;
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Web;
 
 namespace TelegramDownloader.Controllers.Mobile
@@ -856,6 +858,260 @@ namespace TelegramDownloader.Controllers.Mobile
                 ".opus" => "audio/opus",
                 _ => "application/octet-stream"
             };
+        }
+
+        // ============ Audio transcoding (offline downloads in MP3/AAC) ============
+
+        private static bool? _ffmpegAvailable;
+        private static readonly SemaphoreSlim _transcodeSemaphore = new(2); // Max 2 concurrent FFmpeg processes
+        private static readonly ConcurrentDictionary<string, SemaphoreSlim> _transcodeLocks = new();
+
+        private static bool IsFFmpegAvailable()
+        {
+            if (_ffmpegAvailable.HasValue) return _ffmpegAvailable.Value;
+            try
+            {
+                using var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "ffmpeg",
+                        Arguments = "-version",
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    }
+                };
+                process.Start();
+                process.WaitForExit(5000);
+                _ffmpegAvailable = process.ExitCode == 0;
+            }
+            catch
+            {
+                _ffmpegAvailable = false;
+            }
+            return _ffmpegAvailable.Value;
+        }
+
+        /// <summary>
+        /// Capacidades de transcodificación del servidor
+        /// </summary>
+        /// <remarks>
+        /// Permite al cliente comprobar si el servidor tiene FFmpeg disponible antes de
+        /// ofrecer descargas transcodificadas. Si no lo está, el cliente debe avisar al
+        /// usuario y descargar en formato original.
+        /// </remarks>
+        [HttpGet("transcode/info")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public IActionResult GetTranscodeInfo()
+        {
+            var available = IsFFmpegAvailable();
+            return Ok(ApiResponse<object>.Ok(new
+            {
+                ffmpegAvailable = available,
+                formats = available ? new[] { "mp3", "aac" } : Array.Empty<string>()
+            }));
+        }
+
+        /// <summary>
+        /// Descargar audio transcodificado a MP3 o AAC (para descargas offline)
+        /// </summary>
+        /// <remarks>
+        /// Transcodifica el archivo original (p.ej. FLAC) al formato y bitrate indicados
+        /// usando FFmpeg y lo sirve con soporte Range. El resultado se cachea en disco,
+        /// por lo que peticiones posteriores son inmediatas.
+        ///
+        /// Requiere FFmpeg instalado en el servidor: si no está disponible responde
+        /// **501 Not Implemented** y el cliente debe descargar el original.
+        ///
+        /// La primera petición puede tardar: descarga el original de Telegram (si no está
+        /// cacheado) y ejecuta la transcodificación antes de responder.
+        /// </remarks>
+        /// <param name="channelId">ID del canal de Telegram</param>
+        /// <param name="tfmId">ID del archivo en la base de datos TFM</param>
+        /// <param name="format">Formato destino: mp3 | aac</param>
+        /// <param name="bitrate">Bitrate en kbps (64-320)</param>
+        /// <param name="fileName">Nombre del archivo original (opcional)</param>
+        [HttpGet("tfm/{channelId}/{tfmId}/transcoded")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status206PartialContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status501NotImplemented)]
+        public async Task<IActionResult> StreamTranscodedAudio(
+            string channelId,
+            string tfmId,
+            [FromQuery] string format = "mp3",
+            [FromQuery] int bitrate = 192,
+            [FromQuery] string? fileName = null)
+        {
+            try
+            {
+                format = format.ToLowerInvariant();
+                if (format != "mp3" && format != "aac")
+                {
+                    return BadRequest(ApiResponse<object>.Fail("Unsupported format. Use mp3 or aac."));
+                }
+                bitrate = Math.Clamp(bitrate, 64, 320);
+
+                if (!IsFFmpegAvailable())
+                {
+                    return StatusCode(StatusCodes.Status501NotImplemented,
+                        ApiResponse<object>.Fail("FFmpeg is not available on the server"));
+                }
+
+                var dbFile = await _fs.getItemById(channelId, tfmId);
+                if (dbFile == null)
+                {
+                    return NotFound(ApiResponse<object>.Fail("File not found in database"));
+                }
+
+                var name = fileName ?? dbFile.Name;
+                var cacheFileName = $"{channelId}-{(dbFile.MessageId != null ? dbFile.MessageId.ToString() : dbFile.Id)}-{name}";
+                var tempPath = Path.Combine(FileService.TEMPDIR, "_temp");
+                var sourcePath = Path.Combine(tempPath, cacheFileName);
+                var transcodedDir = Path.Combine(tempPath, "transcoded");
+                Directory.CreateDirectory(transcodedDir);
+
+                var targetExt = format == "mp3" ? "mp3" : "m4a";
+                var mimeType = format == "mp3" ? "audio/mpeg" : "audio/mp4";
+                var targetName = $"{Path.GetFileNameWithoutExtension(cacheFileName)}-{format}{bitrate}.{targetExt}";
+                var targetPath = Path.Combine(transcodedDir, targetName);
+                var downloadName = $"{Path.GetFileNameWithoutExtension(name)}.{targetExt}";
+
+                // Cached transcode: serve immediately with Range support
+                if (System.IO.File.Exists(targetPath))
+                {
+                    return PhysicalFile(targetPath, mimeType, downloadName, enableRangeProcessing: true);
+                }
+
+                // Per-target lock so concurrent requests don't transcode twice
+                var fileLock = _transcodeLocks.GetOrAdd(targetName, _ => new SemaphoreSlim(1, 1));
+                await fileLock.WaitAsync(HttpContext.RequestAborted);
+                try
+                {
+                    if (!System.IO.File.Exists(targetPath))
+                    {
+                        // Ensure the original is fully cached first
+                        if (!System.IO.File.Exists(sourcePath) || new FileInfo(sourcePath).Length < dbFile.Size)
+                        {
+                            _logger.LogInformation("Downloading original before transcode: {FileName}", name);
+                            await DownloadOriginalToCache(channelId, dbFile, sourcePath);
+                        }
+
+                        await _transcodeSemaphore.WaitAsync(HttpContext.RequestAborted);
+                        try
+                        {
+                            _logger.LogInformation("Transcoding {FileName} to {Format} {Bitrate}k", name, format, bitrate);
+                            await TranscodeAudioFile(sourcePath, targetPath, format, bitrate, HttpContext.RequestAborted);
+                        }
+                        finally
+                        {
+                            _transcodeSemaphore.Release();
+                        }
+                    }
+                }
+                finally
+                {
+                    fileLock.Release();
+                }
+
+                return PhysicalFile(targetPath, mimeType, downloadName, enableRangeProcessing: true);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogDebug("Transcoded download cancelled for {TfmId}", tfmId);
+                return new EmptyResult();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error transcoding {TfmId} from channel {ChannelId}", tfmId, channelId);
+                return StatusCode(500, ApiResponse<object>.Fail("Error transcoding audio"));
+            }
+        }
+
+        // Sequential full download of the original file into the streaming cache
+        private async Task DownloadOriginalToCache(string channelId, BsonFileManagerModel dbFile, string path)
+        {
+            if (!dbFile.MessageId.HasValue)
+            {
+                throw new InvalidOperationException("File has no MessageId");
+            }
+
+            var message = await _ts.getMessageFile(channelId, dbFile.MessageId.Value);
+            if (message == null)
+            {
+                throw new InvalidOperationException("Message not found in Telegram");
+            }
+
+            using var fileStream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
+            var offset = fileStream.Length;
+            fileStream.Seek(0, SeekOrigin.End);
+
+            const int chunkSize = 512 * 1024;
+            while (offset < dbFile.Size)
+            {
+                HttpContext.RequestAborted.ThrowIfCancellationRequested();
+                var toDownload = (int)Math.Min(chunkSize, dbFile.Size - offset);
+                var chunk = await _ts.DownloadFileStream(message, offset, toDownload);
+                if (chunk.Length == 0) break;
+                await fileStream.WriteAsync(chunk, 0, chunk.Length, HttpContext.RequestAborted);
+                offset += chunk.Length;
+            }
+            await fileStream.FlushAsync();
+        }
+
+        // Run FFmpeg to a temp file, then move into place so partial results
+        // are never served
+        private async Task TranscodeAudioFile(string sourcePath, string targetPath, string format, int bitrate, CancellationToken ct)
+        {
+            var tempOut = targetPath + ".part";
+
+            // mp3: keep embedded cover art (optional video stream copied as attached pic)
+            // aac/m4a: audio only (cover copying into ipod container is less reliable)
+            var codecArgs = format == "mp3"
+                ? $"-map 0:a:0 -map 0:v? -c:v copy -disposition:v:0 attached_pic -codec:a libmp3lame -b:a {bitrate}k -id3v2_version 3 -f mp3"
+                : $"-vn -codec:a aac -b:a {bitrate}k -movflags +faststart -f ipod";
+
+            var args = $"-y -i \"{sourcePath}\" -map_metadata 0 {codecArgs} \"{tempOut}\"";
+
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "ffmpeg",
+                    Arguments = args,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            _ = process.StandardOutput.ReadToEndAsync();
+
+            try
+            {
+                await process.WaitForExitAsync(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { /* already exited */ }
+                try { System.IO.File.Delete(tempOut); } catch { /* best effort */ }
+                throw;
+            }
+
+            if (process.ExitCode != 0)
+            {
+                var stderr = await stderrTask;
+                try { System.IO.File.Delete(tempOut); } catch { /* best effort */ }
+                throw new InvalidOperationException(
+                    $"FFmpeg exited with code {process.ExitCode}: {stderr.Substring(0, Math.Min(500, stderr.Length))}");
+            }
+
+            System.IO.File.Move(tempOut, targetPath, overwrite: true);
         }
     }
 }


### PR DESCRIPTION
## Summary

The TFM Audio PWA can now offer offline playlist downloads in MP3/AAC so lossless files (FLAC) take 5-8x less space on the phone. This PR adds the server side: an FFmpeg-based transcoding endpoint with disk caching, plus a capabilities endpoint so clients can detect whether FFmpeg is installed and warn the user.

## Endpoints

- `GET /api/mobile/stream/transcode/info` — reports `{ ffmpegAvailable, formats }`. Clients must check this (or handle the 501 below) and fall back to original-format downloads when FFmpeg is missing.
- `GET /api/mobile/stream/tfm/{channelId}/{tfmId}/transcoded?format=mp3|aac&bitrate=64..320&fileName=...` —
  1. Ensures the original is fully cached in `_temp` (sequential 512KB Telegram download, same cache file the streaming endpoints use).
  2. Transcodes with FFmpeg (`libmp3lame` / native `aac`), writing to a `.part` file and moving into place so partial results are never served.
  3. Serves the cached result via `PhysicalFile` with full Range support. Repeat requests hit the disk cache under `_temp/transcoded`.

## Safeguards

- **501 Not Implemented** when FFmpeg is not installed (checked once and cached; `transcode/info` reports it too).
- Per-target locks prevent duplicate transcodes of the same file/format/bitrate; a global semaphore caps concurrent FFmpeg processes at 2.
- FFmpeg process is killed (entire tree) and the partial output deleted if the client aborts; non-zero exit codes surface the stderr tail in the server log.
- MP3 output keeps tags and embedded cover art (`-map 0:v? -c:v copy -disposition:v:0 attached_pic`); AAC/m4a keeps tags (`-map_metadata 0`).

## Notes

- First request for a track can take a while (Telegram download + transcode happen synchronously before the response); subsequent requests are instant.
- No new configuration: FFmpeg is resolved from PATH, matching the existing video transcoding feature.

## Test plan

- [ ] `GET /api/mobile/stream/transcode/info` returns `ffmpegAvailable: true` on a host with FFmpeg, `false` without it.
- [ ] Request a FLAC track with `?format=mp3&bitrate=192`: response is a valid MP3 (~5-8x smaller), with tags/cover; file appears under `local/temp/_temp/transcoded/`.
- [ ] Second request for the same track returns instantly (cache hit).
- [ ] `?format=aac` produces a playable .m4a.
- [ ] Without FFmpeg installed, the endpoint returns 501 with a JSON error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
