### PR TITLE
fix: reliable live task updates in Tasks Manager

### DIFF
--- a/TelegramDownloader/Pages/Downloads.razor
+++ b/TelegramDownloader/Pages/Downloads.razor
@@ -6,6 +6,8 @@
 @using TelegramDownloader.Services
 @using Microsoft.AspNetCore.WebUtilities
 
+@implements IDisposable
+
 @inject TransactionInfoService tis
 @inject NavigationManager NavigationManager
 @inject ITaskPersistenceService taskPersistence
@@ -182,7 +184,22 @@
 
     protected override async Task OnInitializedAsync()
     {
+        tis.TransactionsChanged += OnTransactionsChanged;
         await LoadPersistedTasksCount();
+    }
+
+    private async void OnTransactionsChanged(object sender, System.EventArgs e)
+    {
+        try
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+        catch { }
+    }
+
+    public void Dispose()
+    {
+        tis.TransactionsChanged -= OnTransactionsChanged;
     }
 
     private async Task LoadPersistedTasksCount()

--- a/TelegramDownloader/Pages/Partials/DownloadsTable.razor
+++ b/TelegramDownloader/Pages/Partials/DownloadsTable.razor
@@ -94,7 +94,7 @@
 @code {
     [Parameter]
     public bool isPending { get; set; } = false;
-    public static List<DownloadModel> ldm = new List<DownloadModel>();
+    private List<DownloadModel> ldm = new List<DownloadModel>();
     BlazorBootstrap.Grid<DownloadModel> grid = default!;
     DownloadFileInfoModal infoModal { get; set; }
     private bool _disposed = false;
@@ -163,17 +163,16 @@
         };
     }
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        checkNewEventsHandler();
-        tis.EventChanged += eventChangedNew;
+        tis.TransactionsChanged += OnTransactionsChanged;
     }
 
     private async Task<GridDataProviderResult<DownloadModel>> DownloadsDataProvider(GridDataProviderRequest<DownloadModel> request)
     {
-        await getDownloadModels(request.PageNumber - 1, request.PageSize, ldm.Count() == 0);
-        int totalUploads = tis.getTotalDownloads(isPending);
-        return await Task.FromResult(new GridDataProviderResult<DownloadModel> { Data = ldm ?? new List<DownloadModel>(), TotalCount = totalUploads });//request.ApplyTo(uploads));
+        ldm = tis.GetDownloadModels(request.PageNumber - 1, request.PageSize, isPending);
+        int totalDownloads = tis.getTotalDownloads(isPending);
+        return await Task.FromResult(new GridDataProviderResult<DownloadModel> { Data = ldm ?? new List<DownloadModel>(), TotalCount = totalDownloads });
     }
 
     private async Task cancel(DownloadModel dm)
@@ -200,45 +199,19 @@
     }
 
 
-    private void checkNewEventsHandler()
+    private async void OnTransactionsChanged(object sender, System.EventArgs e)
     {
-        foreach (DownloadModel dm in ldm)
+        if (_disposed || grid is null) return;
+        try
         {
-            if (dm.progress != 100)
-                dm.EventChanged += eventChanged;
-            else
-                dm.EventChanged -= eventChanged;
+            await InvokeAsync(() => grid.RefreshDataAsync());
         }
-
-    }
-
-    private async Task getDownloadModels(int pageNumber, int pageSize, bool mustCallEnventHandler = false)
-    {
-        ldm = tis.GetDownloadModels(pageNumber, pageSize, isPending);
-        if (mustCallEnventHandler)
-            checkNewEventsHandler();
-    }
-
-    void eventChanged(object sender, DownloadEventArgs e)
-    {
-        if (_disposed) return;
-        grid.RefreshDataAsync();
-    }
-
-    void eventChangedNew(object sender, System.EventArgs e)
-    {
-        if (_disposed) return;
-        checkNewEventsHandler();
-        grid.RefreshDataAsync();
+        catch { }
     }
 
     public void Dispose()
     {
         _disposed = true;
-        tis.EventChanged -= eventChangedNew;
-        foreach (DownloadModel dm in ldm)
-        {
-            dm.EventChanged -= eventChanged;
-        }
+        tis.TransactionsChanged -= OnTransactionsChanged;
     }
 }

--- a/TelegramDownloader/Pages/Partials/TasksTable.razor
+++ b/TelegramDownloader/Pages/Partials/TasksTable.razor
@@ -97,7 +97,7 @@
 @code {
 
     BlazorBootstrap.Grid<InfoDownloadTaksModel> grid = default!;
-    public static List<InfoDownloadTaksModel> lpt = new List<InfoDownloadTaksModel>();
+    private List<InfoDownloadTaksModel> lpt = new List<InfoDownloadTaksModel>();
     TaskInfoModal infoModal { get; set; }
     private bool _disposed = false;
 
@@ -157,46 +157,26 @@
         };
     }
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        checkNewEventsHandler();
-        tis.EventChanged += eventChangedNew;
+        tis.TransactionsChanged += OnTransactionsChanged;
     }
 
     private async Task<GridDataProviderResult<InfoDownloadTaksModel>> TasksDataProvider(GridDataProviderRequest<InfoDownloadTaksModel> request)
     {
-        await getPendingTasksModels(request.PageNumber - 1, request.PageSize, lpt.Count() == 0);
-        int totalUploads = tis.getTotalTasks();
-        return await Task.FromResult(new GridDataProviderResult<InfoDownloadTaksModel> { Data = lpt ?? new List<InfoDownloadTaksModel>(), TotalCount = totalUploads });//request.ApplyTo(uploads));
+        lpt = tis.getInfoDownloadTaksModel(request.PageNumber - 1, request.PageSize);
+        int totalTasks = tis.getTotalTasks();
+        return await Task.FromResult(new GridDataProviderResult<InfoDownloadTaksModel> { Data = lpt ?? new List<InfoDownloadTaksModel>(), TotalCount = totalTasks });
     }
 
-    private async Task getPendingTasksModels(int pageNumber, int pageSize, bool mustCallEnventHandler = false)
+    private async void OnTransactionsChanged(object sender, System.EventArgs e)
     {
-        lpt = tis.getInfoDownloadTaksModel(pageNumber, pageSize);
-        if (mustCallEnventHandler)
-            checkNewEventsHandler();
-    }
-
-    private void checkNewEventsHandler()
-    {
-        foreach (InfoDownloadTaksModel pt in lpt)
+        if (_disposed || grid is null) return;
+        try
         {
-            pt.EventChanged -= eventChangedPendingTask;
-            pt.EventChanged += eventChangedPendingTask;
+            await InvokeAsync(() => grid.RefreshDataAsync());
         }
-    }
-
-    void eventChangedPendingTask(object sender, InfoTaskEventArgs e)
-    {
-        if (_disposed) return;
-        grid.RefreshDataAsync();
-    }
-
-    void eventChangedNew(object sender, System.EventArgs e)
-    {
-        if (_disposed) return;
-        checkNewEventsHandler();
-        grid.RefreshDataAsync();
+        catch { }
     }
 
     private async Task cancel(InfoDownloadTaksModel idt)
@@ -221,10 +201,6 @@
     public void Dispose()
     {
         _disposed = true;
-        tis.EventChanged -= eventChangedNew;
-        foreach (InfoDownloadTaksModel pt in lpt)
-        {
-            pt.EventChanged -= eventChangedPendingTask;
-        }
+        tis.TransactionsChanged -= OnTransactionsChanged;
     }
 }

--- a/TelegramDownloader/Pages/Partials/UploadsTable.razor
+++ b/TelegramDownloader/Pages/Partials/UploadsTable.razor
@@ -104,7 +104,7 @@
     [Parameter]
     public EventCallback OnUploadModalClose { get; set; }
 
-    public static List<UploadModel> lum = new List<UploadModel>();
+    private List<UploadModel> lum = new List<UploadModel>();
     BlazorBootstrap.Grid<UploadModel> grid = default!;
     UploadFileInfoModal infoModal { get; set; }
     private bool _disposed = false;
@@ -199,10 +199,9 @@
         }
     }
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        checkNewEventsHandler();
-        tis.EventChanged += eventChangedNew;
+        tis.TransactionsChanged += OnTransactionsChanged;
     }
 
     private async Task cancel(UploadModel um)
@@ -231,54 +230,24 @@
 
     private async Task<GridDataProviderResult<UploadModel>> UploadsDataProvider(GridDataProviderRequest<UploadModel> request)
     {
-        await getUploadModels(request.PageNumber - 1, request.PageSize, lum.Count() == 0);
+        lum = tis.GetUploadModels(request.PageNumber - 1, request.PageSize, isPending);
         int totalUploads = tis.getTotalUploads(isPending);
         return await Task.FromResult(new GridDataProviderResult<UploadModel> { Data = lum ?? new List<UploadModel>(), TotalCount = totalUploads });
     }
 
-    private async Task getUploadModels(int pageNumber, int pageSize, bool mustCallEnventHandler = false)
+    private async void OnTransactionsChanged(object sender, System.EventArgs e)
     {
-        lum = tis.GetUploadModels(pageNumber, pageSize, isPending);
-        if (mustCallEnventHandler)
-            checkNewEventsHandler();
-    }
-
-    private void checkNewEventsHandler()
-    {
-        if (lum != null)
-            foreach (UploadModel um in lum)
-            {
-                if (um.progress != 100)
-                    um.EventChanged += eventChangedUpload;
-                else
-                    um.EventChanged -= eventChangedUpload;
-            }
-
-    }
-
-    void eventChangedUpload(object sender, UploadEventArgs e)
-    {
-        if (_disposed) return;
-        grid.RefreshDataAsync();
-    }
-
-    void eventChangedNew(object sender, System.EventArgs e)
-    {
-        if (_disposed) return;
-        checkNewEventsHandler();
-        grid.RefreshDataAsync();
+        if (_disposed || grid is null) return;
+        try
+        {
+            await InvokeAsync(() => grid.RefreshDataAsync());
+        }
+        catch { }
     }
 
     public void Dispose()
     {
         _disposed = true;
-        tis.EventChanged -= eventChangedNew;
-        if (lum != null)
-        {
-            foreach (UploadModel um in lum)
-            {
-                um.EventChanged -= eventChangedUpload;
-            }
-        }
+        tis.TransactionsChanged -= OnTransactionsChanged;
     }
 }

--- a/TelegramDownloader/Services/TransactionInfoService.cs
+++ b/TelegramDownloader/Services/TransactionInfoService.cs
@@ -14,6 +14,13 @@ namespace TelegramDownloader.Services
 
         public bool isPauseDownloads = false;
         public event EventHandler<EventArgs> EventChanged;
+        /// <summary>
+        /// Aggregated, throttled event raised whenever any transaction changes:
+        /// list membership (add/remove/clear) or per-model progress/state.
+        /// UI components should subscribe to this single event instead of
+        /// subscribing to each model individually.
+        /// </summary>
+        public event EventHandler TransactionsChanged;
         public event EventHandler TaskEventChanged;
         public event EventHandler HistorykEventChanged;
         public event EventHandler<SpeedHistoryEventArgs> NewSpeedHistoryPoint;
@@ -43,10 +50,111 @@ namespace TelegramDownloader.Services
         private Timer aTimer;
         private readonly ILogger<IFileService> _logger;
 
+        // Throttling for TransactionsChanged: progress callbacks fire per network
+        // chunk, so raise at most once per interval with a guaranteed trailing raise.
+        private static readonly TimeSpan NotifyThrottle = TimeSpan.FromMilliseconds(250);
+        private readonly object _notifyLock = new object();
+        private DateTime _lastNotifyUtc = DateTime.MinValue;
+        private bool _trailingNotifyScheduled = false;
+        private System.Threading.Timer _trailingNotifyTimer;
+
         public TransactionInfoService(ILogger<IFileService> logger)
         {
             _logger = logger;
         }
+
+        /// <summary>
+        /// Raises <see cref="TransactionsChanged"/>, coalescing bursts so
+        /// subscribers refresh at most once per <see cref="NotifyThrottle"/>.
+        /// The last change in a burst is always delivered (trailing raise).
+        /// </summary>
+        public void NotifyTransactionsChanged()
+        {
+            bool raiseNow = false;
+            lock (_notifyLock)
+            {
+                DateTime now = DateTime.UtcNow;
+                if (now - _lastNotifyUtc >= NotifyThrottle)
+                {
+                    _lastNotifyUtc = now;
+                    raiseNow = true;
+                }
+                else if (!_trailingNotifyScheduled)
+                {
+                    _trailingNotifyScheduled = true;
+                    TimeSpan delay = NotifyThrottle - (now - _lastNotifyUtc);
+                    if (delay < TimeSpan.Zero)
+                        delay = TimeSpan.Zero;
+                    if (_trailingNotifyTimer == null)
+                        _trailingNotifyTimer = new System.Threading.Timer(_ => RaiseTrailingNotify(), null, delay, Timeout.InfiniteTimeSpan);
+                    else
+                        _trailingNotifyTimer.Change(delay, Timeout.InfiniteTimeSpan);
+                }
+            }
+            if (raiseNow)
+                SafeRaiseTransactionsChanged();
+        }
+
+        private void RaiseTrailingNotify()
+        {
+            lock (_notifyLock)
+            {
+                _trailingNotifyScheduled = false;
+                _lastNotifyUtc = DateTime.UtcNow;
+            }
+            SafeRaiseTransactionsChanged();
+        }
+
+        private void SafeRaiseTransactionsChanged()
+        {
+            try
+            {
+                TransactionsChanged?.Invoke(this, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error notifying TransactionsChanged subscribers");
+            }
+        }
+
+        // The service owns the per-model subscriptions so UI components do not
+        // have to track which models are wired. Hooking is idempotent.
+        private void hookModel(DownloadModel dm)
+        {
+            dm.EventChanged -= onDownloadModelChanged;
+            dm.EventChanged += onDownloadModelChanged;
+        }
+
+        private void unhookModel(DownloadModel dm)
+        {
+            dm.EventChanged -= onDownloadModelChanged;
+        }
+
+        private void hookModel(UploadModel um)
+        {
+            um.EventChanged -= onUploadModelChanged;
+            um.EventChanged += onUploadModelChanged;
+        }
+
+        private void unhookModel(UploadModel um)
+        {
+            um.EventChanged -= onUploadModelChanged;
+        }
+
+        private void hookModel(InfoDownloadTaksModel idt)
+        {
+            idt.EventChanged -= onInfoTaskModelChanged;
+            idt.EventChanged += onInfoTaskModelChanged;
+        }
+
+        private void unhookModel(InfoDownloadTaksModel idt)
+        {
+            idt.EventChanged -= onInfoTaskModelChanged;
+        }
+
+        private void onDownloadModelChanged(object sender, DownloadEventArgs e) => NotifyTransactionsChanged();
+        private void onUploadModelChanged(object sender, UploadEventArgs e) => NotifyTransactionsChanged();
+        private void onInfoTaskModelChanged(object sender, InfoTaskEventArgs e) => NotifyTransactionsChanged();
         public bool isWorking()
         {
             if (!(isDownloading() || isUploading()))
@@ -250,8 +358,10 @@ namespace TelegramDownloader.Services
                 downloadModel.name, downloadModel._size / (1024.0 * 1024.0));
             downloadModels.Insert(0, downloadModel);
             PendingDownloadMutex.ReleaseMutex();
+            hookModel(downloadModel);
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public void addToPendingDownloadList(DownloadModel downloadModel, bool atFirst = false, bool chekDownloads = true)
@@ -275,6 +385,8 @@ namespace TelegramDownloader.Services
             else
                 pendingDownloadModels.Add(downloadModel);
             PendingDownloadMutex.ReleaseMutex();
+            hookModel(downloadModel);
+            NotifyTransactionsChanged();
             if (chekDownloads)
                 CheckPendingDownloads();
         }
@@ -291,6 +403,7 @@ namespace TelegramDownloader.Services
             }
             PendingDownloadMutex.ReleaseMutex();
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public void PlayDownloads()
@@ -315,6 +428,7 @@ namespace TelegramDownloader.Services
             pendingDownloadModels.Clear();
             PendingDownloadMutex.ReleaseMutex();
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public async Task CheckPendingDownloads()
@@ -328,12 +442,14 @@ namespace TelegramDownloader.Services
                 DownloadModel dm = pendingDownloadModels.FirstOrDefault();
                 downloadModels.Insert(0, dm);
                 pendingDownloadModels.Remove(dm);
+                hookModel(dm);
                 startTimer();
                 dm.RetryCallback();
             }
             PendingDownloadMutex.ReleaseMutex();
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public async Task CheckPendingUploadInfoTasks()
@@ -344,12 +460,14 @@ namespace TelegramDownloader.Services
             {
                 InfoDownloadTaksModel idt = infoDownloadTaksModel.Where(x => x.state == StateTask.Pending).OrderBy(x => x.creationDate).FirstOrDefault();
                 idt.state = StateTask.Working;
+                hookModel(idt);
                 startTimer();
                 idt.RetryCallback();
             }
             PendingUploadInfoTaskMutex.ReleaseMutex();
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public void addToUploadList(UploadModel uploadModel)
@@ -365,15 +483,19 @@ namespace TelegramDownloader.Services
             _logger.LogInformation("Adding to upload list - Name: {Name}, Size: {SizeMB:F2}MB",
                 uploadModel.name, uploadModel._size / (1024.0 * 1024.0));
             uploadModels.Insert(0, uploadModel);
+            hookModel(uploadModel);
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public void deleteUploadInList(UploadModel uploadModel)
         {
             uploadModels.Remove(uploadModel);
+            unhookModel(uploadModel);
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public void addToInfoDownloadTaskList(InfoDownloadTaksModel infoDownloadModel)
@@ -381,6 +503,8 @@ namespace TelegramDownloader.Services
             PendingUploadInfoTaskMutex.WaitOne();
             infoDownloadTaksModel.Add(infoDownloadModel);
             PendingUploadInfoTaskMutex.ReleaseMutex();
+            hookModel(infoDownloadModel);
+            NotifyTransactionsChanged();
             CheckPendingUploadInfoTasks();
         }
 
@@ -430,8 +554,10 @@ namespace TelegramDownloader.Services
 
             pendingUploadModels.Add(uploadModel);
             PendingUploadMutex.ReleaseMutex();
+            hookModel(uploadModel);
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public void deletePendingUploadInList(UploadModel uploadModel)
@@ -439,8 +565,11 @@ namespace TelegramDownloader.Services
             PendingUploadMutex.WaitOne();
             pendingUploadModels.Remove(uploadModel);
             PendingUploadMutex.ReleaseMutex();
+            if (!uploadModels.Contains(uploadModel))
+                unhookModel(uploadModel);
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public void deleteDownloadInList(DownloadModel downloadModel)
@@ -448,8 +577,13 @@ namespace TelegramDownloader.Services
             PendingDownloadMutex.WaitOne();
             downloadModels.Remove(downloadModel);
             PendingDownloadMutex.ReleaseMutex();
+            // A paused download is removed from the active list but stays in the
+            // pending list, so keep it hooked in that case.
+            if (!pendingDownloadModels.Contains(downloadModel))
+                unhookModel(downloadModel);
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public void deletePendingDownloadInList(DownloadModel downloadModel)
@@ -457,28 +591,39 @@ namespace TelegramDownloader.Services
             PendingDownloadMutex.WaitOne();
             pendingDownloadModels.Remove(downloadModel);
             PendingDownloadMutex.ReleaseMutex();
+            if (!downloadModels.Contains(downloadModel))
+                unhookModel(downloadModel);
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public void ClearPendingDownloads()
         {
             _logger.LogInformation("Clearing all pending downloads - Count: {Count}", pendingDownloadModels.Count);
             PendingDownloadMutex.WaitOne();
+            List<DownloadModel> removed = pendingDownloadModels.ToList();
             pendingDownloadModels.Clear();
             PendingDownloadMutex.ReleaseMutex();
+            foreach (DownloadModel dm in removed.Where(x => !downloadModels.Contains(x)))
+                unhookModel(dm);
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public void ClearPendingUploads()
         {
             _logger.LogInformation("Clearing all pending uploads - Count: {Count}", pendingUploadModels.Count);
             PendingUploadMutex.WaitOne();
+            List<UploadModel> removed = pendingUploadModels.ToList();
             pendingUploadModels.Clear();
             PendingUploadMutex.ReleaseMutex();
+            foreach (UploadModel um in removed.Where(x => !uploadModels.Contains(x)))
+                unhookModel(um);
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public void deleteInfoDownloadTaskFromList(InfoDownloadTaksModel idt)
@@ -486,8 +631,10 @@ namespace TelegramDownloader.Services
             PendingUploadInfoTaskMutex.WaitOne();
             infoDownloadTaksModel.Remove(idt);
             PendingUploadInfoTaskMutex.ReleaseMutex();
+            unhookModel(idt);
             EventChanged?.Invoke(this, new EventArgs());
             TaskEventChanged?.Invoke(null, EventArgs.Empty);
+            NotifyTransactionsChanged();
         }
 
         public List<InfoDownloadTaksModel> getInfoDownloadTaksModel(int pageNumber, int pageSize)
@@ -504,22 +651,34 @@ namespace TelegramDownloader.Services
 
         public void clearUploadCompleted()
         {
+            List<UploadModel> removed = uploadModels.Where(x => x.state != StateTask.Working).ToList();
             uploadModels.RemoveAll(x => x.state != StateTask.Working);
+            foreach (UploadModel um in removed)
+                unhookModel(um);
             EventChanged?.Invoke(this, new EventArgs());
+            NotifyTransactionsChanged();
         }
 
         public void clearDownloadCompleted()
         {
             PendingDownloadMutex.WaitOne();
+            List<DownloadModel> removed = downloadModels.Where(x => x.state != StateTask.Working).ToList();
             downloadModels.RemoveAll(x => x.state != StateTask.Working);
             PendingDownloadMutex.ReleaseMutex();
+            foreach (DownloadModel dm in removed.Where(x => !pendingDownloadModels.Contains(x)))
+                unhookModel(dm);
             EventChanged?.Invoke(this, new EventArgs());
+            NotifyTransactionsChanged();
         }
 
         public void clearTasksCompleted()
         {
+            List<InfoDownloadTaksModel> removed = infoDownloadTaksModel.Where(x => x.state != StateTask.Working).ToList();
             infoDownloadTaksModel.RemoveAll(x => x.state != StateTask.Working);
+            foreach (InfoDownloadTaksModel idt in removed)
+                unhookModel(idt);
             EventChanged?.Invoke(this, new EventArgs());
+            NotifyTransactionsChanged();
         }
 
 


### PR DESCRIPTION
## Problem
When creating an upload/download task and navigating to the Tasks page, tables did not update live — a full page reload was needed for progress events to reach the UI.

## Root causes
- Per-model `EventChanged` subscriptions were only (re)wired when the component's cached list was empty (`lpt.Count() == 0`), so newly created models never got subscribed after the first visit.
- The cached lists were `static`, shared between the Active and Queue instances of the same table component (they overwrote each other and cross-unsubscribed on `Dispose`), and persisted across navigations.
- Event handlers called `grid.RefreshDataAsync()` from background threads without `InvokeAsync`, fire-and-forget, swallowing any failure.
- Every network chunk triggered a full grid refresh (no throttling).

## Changes
- `TransactionInfoService` now owns all per-model subscriptions: models are hooked when they enter any list (active/pending, uploads/downloads/batch tasks) and unhooked on remove/clear. Any change — list membership or per-model progress/state — is published through a single new `TransactionsChanged` event, throttled to 250ms with a guaranteed trailing raise so the final state of a burst is always delivered.
- `TasksTable`, `UploadsTable` and `DownloadsTable` were simplified: instance (non-static) lists, a single subscription to `TransactionsChanged`, refresh marshaled through `InvokeAsync` with exception handling. No per-model event wiring in the UI anymore.
- The Tasks Manager header stat cards (Batch Tasks / Downloads / Uploads) now update live too.

Existing events (`EventChanged`, `TaskEventChanged`, speed history events) are kept intact for `MainLayout` and `SpeedChart`.