### PR TITLE
feat: configurable parallel chunk transfers for faster downloads/uploads

### DIFF
--- a/TelegramDownloader/Data/TelegramService.cs
+++ b/TelegramDownloader/Data/TelegramService.cs
@@ -161,6 +161,7 @@ namespace TelegramDownloader.Data
         private void newClient()
         {
             client = new WTelegram.Client(Convert.ToInt32(GeneralConfigStatic.tlconfig?.api_id ?? Environment.GetEnvironmentVariable("api_id")), GeneralConfigStatic.tlconfig?.hash_id ?? Environment.GetEnvironmentVariable("hash_id"), UserService.USERDATAFOLDER + "/WTelegram.session");
+            ApplyConfiguredParallelTransfers(client);
             if (GeneralConfigStatic.config.ShouldShowLogInTerminal)
             {
                 // WTelegram.Helpers.Log = (lvl, str) => Console.WriteLine($"{DateTime.Now:yyyy-MM-dd HH:mm:ss} [{"TDIWE!"[lvl]}] {str}");
@@ -169,6 +170,67 @@ namespace TelegramDownloader.Data
                 WTelegram.Helpers.Log = (lvl, str) => { };
             }
 
+        }
+
+        // WTelegramClient requests file parts through a per-client semaphore that
+        // defaults to 2 parts in flight, capping transfers at ~1MB per round-trip.
+        // Tracks the value applied to each client instance (main client and the
+        // media-DC clients WTelegram creates internally, which do NOT inherit the
+        // main client's ParallelTransfers).
+        private static readonly ConditionalWeakTable<WTelegram.Client, StrongBox<int>> appliedParallelTransfers = new();
+        private const int WTELEGRAM_DEFAULT_PARALLEL_TRANSFERS = 2;
+
+        public static int GetConfiguredParallelTransfers()
+        {
+            return Math.Clamp(GeneralConfigStatic.config?.ParallelTransfers ?? 4, 1, 16);
+        }
+
+        private static void ApplyConfiguredParallelTransfers(WTelegram.Client c)
+        {
+            if (c == null)
+                return;
+            int desired = GetConfiguredParallelTransfers();
+            int delta;
+            lock (appliedParallelTransfers)
+            {
+                StrongBox<int> applied = appliedParallelTransfers.GetOrCreateValue(c);
+                if (applied.Value == 0)
+                    applied.Value = WTELEGRAM_DEFAULT_PARALLEL_TRANSFERS;
+                delta = desired - applied.Value;
+                if (delta == 0)
+                    return;
+                applied.Value = desired;
+            }
+            try
+            {
+                // The ParallelTransfers setter adjusts the semaphore relative to its
+                // CURRENT count, which is lower while parts are in flight. Applying
+                // our delta on top of the current value keeps the configured maximum
+                // correct even if a transfer is running on this client.
+                c.ParallelTransfers = c.ParallelTransfers + delta;
+            }
+            catch (Exception)
+            {
+                // Never let a tuning failure break a transfer.
+            }
+        }
+
+        /// <summary>
+        /// Resolves the client instance that WTelegram's DownloadFileAsync will use
+        /// for the given file DC (dc_id == 0 means the main client) and applies the
+        /// configured chunk parallelism to it before the transfer starts.
+        /// </summary>
+        private async Task PrepareTransferClientAsync(int dcId)
+        {
+            try
+            {
+                WTelegram.Client c = dcId == 0 ? client : await client.GetClientForDC(-dcId, true);
+                ApplyConfiguredParallelTransfers(c);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Could not prepare transfer client for DC {DcId}", dcId);
+            }
         }
 
         public async Task<User> CallQrGenerator(Action<string> func, CancellationToken ct, bool logoutFirst = false)
@@ -701,6 +763,7 @@ namespace TelegramDownloader.Data
 
             try
             {
+                ApplyConfiguredParallelTransfers(client);
                 var inputFile = await client.UploadFileAsync(file, fileName, um.ProgressCallback);
                 var result = await client.SendMediaAsync(peer, caption ?? fileName, inputFile, mimeType);
                 _logger.LogInformation("File upload completed - FileName: {FileName}, MessageId: {MessageId}", fileName, result.id);
@@ -1205,6 +1268,7 @@ namespace TelegramDownloader.Data
                     model.name = filename;
                 _logger.LogInformation("Starting document download - FileName: {FileName}, Size: {SizeMB:F2}MB", filename, document.size / (1024.0 * 1024.0));
                 MemoryStream dest = new MemoryStream();
+                await PrepareTransferClientAsync(document.dc_id);
                 await client.DownloadFileAsync(document, ms ?? dest, (PhotoSizeBase)null, model.ProgressCallback);
                 _logger.LogInformation("Document download completed - FileName: {FileName}", filename);
                 return ms ?? dest;
@@ -1253,6 +1317,7 @@ namespace TelegramDownloader.Data
                 if (offset == 0)
                 {
                     MemoryStream dest = new MemoryStream();
+                    await PrepareTransferClientAsync(document.dc_id);
                     await client.DownloadFileAsync(document, ms ?? dest, (PhotoSizeBase)null, model.ProgressCallback);
                     _logger.LogInformation("Document download completed - FileName: {FileName}", filename);
                     return ms ?? dest;
@@ -1365,6 +1430,7 @@ namespace TelegramDownloader.Data
                     _tis.addToDownloadList(model);
                 _logger.LogInformation("Starting file download to disk - FileName: {FileName}, Size: {SizeMB:F2}MB", filename, document.size / (1024.0 * 1024.0));
                 using var dest = new FileStream($"{Path.Combine(folder != null ? folder : Path.Combine(Environment.CurrentDirectory, "local", "temp"), filename)}", FileMode.Create, FileAccess.Write);
+                await PrepareTransferClientAsync(document.dc_id);
                 await client.DownloadFileAsync(document, dest, (PhotoSizeBase)null, model.ProgressCallback);
                 _logger.LogInformation("File download to disk completed - FileName: {FileName}", filename);
             }

--- a/TelegramDownloader/Models/GeneralConfig.cs
+++ b/TelegramDownloader/Models/GeneralConfig.cs
@@ -178,6 +178,17 @@ namespace TelegramDownloader.Models
         /// </summary>
         public int MemorySplitSizeGB { get; set; } = 2;
 
+        // Transfer Speed Settings
+        /// <summary>
+        /// Number of 512KB file chunks requested in parallel per transfer (1-16).
+        /// WTelegramClient's default of 2 caps throughput at roughly 1MB per
+        /// round-trip to Telegram's data center (~5-7 MB/s on typical latency).
+        /// Higher values remove that latency bottleneck; the server-side speed
+        /// limit for non-Premium accounts still applies. Takes effect on the
+        /// next transfer, no restart needed.
+        /// </summary>
+        public int ParallelTransfers { get; set; } = 4;
+
     }
 
     public class TLConfig

--- a/TelegramDownloader/Pages/Config.razor
+++ b/TelegramDownloader/Pages/Config.razor
@@ -233,6 +233,21 @@
                     <div class="config-item">
                         <div class="config-item-info">
                             <div class="config-item-label">
+                                <i class="bi bi-lightning-charge"></i>
+                                Parallel Chunk Transfers
+                            </div>
+                            <div class="config-item-description">
+                                Number of 512KB chunks requested in parallel per transfer (1-16). Higher values improve download/upload speed by removing the latency bottleneck; Premium accounts benefit the most. Applied on the next transfer.
+                            </div>
+                        </div>
+                        <div class="config-item-control">
+                            <NumberInput TValue="int" @bind-Value="Model!.ParallelTransfers" Min="1" Max="16" EnableMinMax="true" class="form-control" style="width: 80px;" />
+                        </div>
+                    </div>
+
+                    <div class="config-item">
+                        <div class="config-item-info">
+                            <div class="config-item-label">
                                 <i class="bi bi-file-earmark-arrow-down"></i>
                                 Max. Preload File Size
                             </div>


### PR DESCRIPTION
## Problem
Downloads and uploads top out around 5-7 MB/s regardless of available bandwidth.

## Diagnosis
WTelegramClient transfers files in 512KB parts through a per-client semaphore (`ParallelTransfers`) that defaults to **2 requests in flight** (it was 10 in older versions; the author lowered it as optimal for non-premium accounts). With ~80-150ms RTT to Telegram's DCs, throughput is latency-bound at roughly `2 x 512KB / RTT` — which is exactly the observed 5-7 MB/s.

Two facts verified against the WTelegramClient source:
- `DownloadFileAsync`/`UploadFileAsync` already pipeline parts up to `ParallelTransfers`, so raising it is safe and supported.
- The secondary media-DC clients created internally via `GetClientForDC(-dc_id, true)` do **not** inherit the main client's `ParallelTransfers`, so the setting must be propagated to the exact client instance the download will use.

## Changes
- New `ParallelTransfers` setting in General Config (default 4, range 1-16) with a NumberInput in the Config page, next to Max. Simultaneous Downloads.
- `TelegramService` applies the configured value to the main client on creation and, before each document download, to the media-DC client WTelegram will use (resolved with the same `dc_id == 0 ? main : GetClientForDC(-dc_id)` logic the library uses internally).
- The applied value is tracked per client instance and adjusted by delta on top of the current semaphore count, so re-applying or changing the config while parts are in flight cannot inflate or corrupt the limit. Config changes take effect on the next transfer, no restart needed.

## Expected impact
Removing the latency bottleneck typically raises transfers well beyond 5-7 MB/s. Note that Telegram still applies a server-side speed cap for non-Premium accounts, so the ceiling depends on the account; Premium accounts benefit the most. If Telegram ever returns flood warnings at high values, lowering the setting back to 2 restores the previous behavior.
