### PR TITLE
fix: enable multi-connection mode on the file-manager download path

### DIFF
--- a/TelegramDownloader/Data/TelegramService.cs
+++ b/TelegramDownloader/Data/TelegramService.cs
@@ -1525,8 +1525,16 @@ namespace TelegramDownloader.Data
                     model.name = filename;
                 _logger.LogInformation("Starting document download - FileName: {FileName}, Size: {SizeMB:F2}MB", filename, document.size / (1024.0 * 1024.0));
                 MemoryStream dest = new MemoryStream();
-                await PrepareTransferClientAsync(document.dc_id);
-                await client.DownloadFileAsync(document, ms ?? dest, (PhotoSizeBase)null, model.ProgressCallback);
+                // File-manager download tasks land here with a FileStream target,
+                // which supports positional writes for multi-connection mode.
+                bool multiConnDone = false;
+                if (ms is FileStream fileDest && ShouldUseMultiConnection(document))
+                    multiConnDone = await TryMultiConnectionDownloadAsync(document, fileDest, model);
+                if (!multiConnDone)
+                {
+                    await PrepareTransferClientAsync(document.dc_id);
+                    await client.DownloadFileAsync(document, ms ?? dest, (PhotoSizeBase)null, model.ProgressCallback);
+                }
                 _logger.LogInformation("Document download completed - FileName: {FileName}", filename);
                 return ms ?? dest;
             }
@@ -1574,8 +1582,14 @@ namespace TelegramDownloader.Data
                 if (offset == 0)
                 {
                     MemoryStream dest = new MemoryStream();
-                    await PrepareTransferClientAsync(document.dc_id);
-                    await client.DownloadFileAsync(document, ms ?? dest, (PhotoSizeBase)null, model.ProgressCallback);
+                    bool multiConnDone = false;
+                    if (ms is FileStream fileDest && ShouldUseMultiConnection(document))
+                        multiConnDone = await TryMultiConnectionDownloadAsync(document, fileDest, model);
+                    if (!multiConnDone)
+                    {
+                        await PrepareTransferClientAsync(document.dc_id);
+                        await client.DownloadFileAsync(document, ms ?? dest, (PhotoSizeBase)null, model.ProgressCallback);
+                    }
                     _logger.LogInformation("Document download completed - FileName: {FileName}", filename);
                     return ms ?? dest;
                 }


### PR DESCRIPTION
## Problem
After merging #100, multi-connection downloads never actually triggered on the most common path: no speed change, no pool logs, no fallback warning.

## Cause
The multi-connection hook was only added to `TelegramService.DownloadFile`, which is used by chat-view downloads. File-manager download tasks go through `FileService.DownloadFileNow`, which calls `DownloadFileAndReturn` with a `FileStream` target — that method still used the sequential `client.DownloadFileAsync` unconditionally, so the feature was dead code on the main path.

## Fix
Hook `DownloadFileAndReturn` (and the `offset == 0` branch of `DownloadFileAndReturnWithOffset`) into `TryMultiConnectionDownloadAsync` when the destination stream is a `FileStream`, which supports the positional writes multi-connection mode requires. Memory and non-seekable targets keep the sequential path.

Verified that every `DownloadFileAndReturn` caller (file-manager tasks, `downloadFileToServer`, FileController/VideoStream/MobileStream controllers) awaits the download to completion before serving the file, so out-of-order block writes are safe on these paths; the progressive STRM cache uses its own `DownloadFileStream` method and is unaffected.

## Expected logs when testing
1. `Download pool client {i} ready for DC {dc}` (first use only - session bootstrap)
2. `Multi-connection download - FileName: ..., Connections: N`

If instead `Could not create download pool client...` appears, the DC refused the same-DC exportAuthorization bootstrap and downloads fall back to single-connection.