### PR TITLE
fix: tolerate re-import on an already-authorized pool session key

### DIFF
--- a/TelegramDownloader/Data/TelegramService.cs
+++ b/TelegramDownloader/Data/TelegramService.cs
@@ -350,8 +350,21 @@ namespace TelegramDownloader.Data
                         // With the UserId recorded, WTelegram's GetClientForDC
                         // handles the per-file-DC authorization automatically.
                         Auth_ExportedAuthorization exported = await client.Auth_ExportAuthorization(dc.id);
-                        Auth_AuthorizationBase auth = await pc.Auth_ImportAuthorization(exported.id, exported.bytes);
-                        pc.LoginAlreadyDone(auth);
+                        Auth_AuthorizationBase auth = null;
+                        try
+                        {
+                            auth = await pc.Auth_ImportAuthorization(exported.id, exported.bytes);
+                        }
+                        catch (RpcException rex) when (rex.Message == "AUTH_BYTES_INVALID")
+                        {
+                            // Session persisted by an earlier run whose import
+                            // succeeded but whose login was never finalized: the
+                            // key already holds the account authorization and
+                            // re-importing onto it is rejected. Record the login
+                            // client-side and let the workers verify by use.
+                            _logger.LogInformation("Download pool client {Index}: key already authorized on a previous run", index);
+                        }
+                        pc.LoginAlreadyDone(auth ?? new Auth_Authorization { user = new User { id = exported.id } });
                     }
                     _logger.LogInformation("Download pool client {Index} ready (homed on DC {Dc})", index, dc.id);
                     return pc;


### PR DESCRIPTION
## Problem
After #103, the bootstrap now fails with `AUTH_BYTES_INVALID` on the `auth.importAuthorization` call.

## Cause
Leftover state from the earlier iterations: in the #102-era runs the import actually **succeeded** (only the later verification probe failed), so the key stored in `WTelegram_dl_0.session` already carries the account authorization server-side. The session however never recorded a UserId (`LoginAlreadyDone` did not exist yet in that code), so the new bootstrap treats it as fresh and re-imports — and the server rejects importing onto an already-authorized key with `AUTH_BYTES_INVALID`.

## Fix
Catch `AUTH_BYTES_INVALID` on the import and treat it as already-authorized: finalize the login client-side with the user id that `exportAuthorization` returned (so `GetClientForDC` keeps handling per-file-DC authorization automatically) and let the workers verify the session by use. If the session turns out to be genuinely broken, the download falls back to the sequential path as usual.

Fresh sessions (no leftover files) never hit this branch: connect → import (first call) → `LoginAlreadyDone` works directly.

## Expected logs
1. `Download pool client 0: key already authorized on a previous run` (only with leftover session files)
2. `Download pool client 0 ready (homed on DC 1)`
3. `Multi-connection download - FileName: ..., Connections: N`
