### PR TITLE
feat: auth guard before rendering with return to the requested page

### DIFF
--- a/TelegramDownloader/Pages/Index.razor
+++ b/TelegramDownloader/Pages/Index.razor
@@ -3,6 +3,7 @@
 @implements IDisposable
 
 @using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.WebUtilities
 @using QRCoder
 @using TelegramDownloader.Data
 @using TelegramDownloader.Models
@@ -276,8 +277,32 @@
                     source.Cancel();
                 }
             }
-            NavManager.NavigateTo("/fetchdata");
+            NavManager.NavigateTo(GetReturnUrl() ?? "/fetchdata");
         }
+    }
+
+    /// <summary>
+    /// Returns the page the user originally requested (passed by the layouts'
+    /// auth guard as ?returnUrl=...), so a successful login lands back on it.
+    /// Only local paths are accepted, to avoid open redirects.
+    /// </summary>
+    private string GetReturnUrl()
+    {
+        try
+        {
+            var uri = NavManager.ToAbsoluteUri(NavManager.Uri);
+            if (QueryHelpers.ParseQuery(uri.Query).TryGetValue("returnUrl", out var value))
+            {
+                string url = value.ToString();
+                if (url.StartsWith('/') && !url.StartsWith("//") && url != "/" && !url.StartsWith("/?"))
+                    return url;
+            }
+        }
+        catch
+        {
+            // Malformed query - fall back to the default landing page
+        }
+        return null;
     }
 
     private void GenerateQR(string data)

--- a/TelegramDownloader/Shared/ConfigLayout.razor
+++ b/TelegramDownloader/Shared/ConfigLayout.razor
@@ -8,9 +8,34 @@
 <PageTitle>TelegramFileManager</PageTitle>
 
 @code {
-    protected override void OnInitialized()
+    private bool authResolved { get; set; } = false;
+
+    protected override async Task OnInitializedAsync()
     {
-        if (!ts.checkUserLogin()) NavManager.NavigateTo("/");
+        // Same auth guard as MainLayout: resolve the session before rendering
+        // any page content, trying a silent restore first and keeping the
+        // requested URL when interactive login is needed.
+        if (!ts.checkUserLogin())
+        {
+            string authType = null;
+            try
+            {
+                authType = await ts.checkAuth(null);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            if (authType != "ok")
+            {
+                string returnUrl = new Uri(NavManager.Uri).PathAndQuery;
+                NavManager.NavigateTo(string.IsNullOrEmpty(returnUrl) || returnUrl == "/"
+                    ? "/"
+                    : $"/?returnUrl={Uri.EscapeDataString(returnUrl)}", forceLoad: true);
+                return;
+            }
+        }
+        authResolved = true;
     }
 }
 
@@ -39,7 +64,10 @@
         </div>
         <TelegramDownloader.Pages.Modals.ToastNotify></TelegramDownloader.Pages.Modals.ToastNotify>
         <article class="content px-4">
-            @Body
+            @if (authResolved)
+            {
+                @Body
+            }
         </article>
     </main>
 </div>

--- a/TelegramDownloader/Shared/MainLayout.razor
+++ b/TelegramDownloader/Shared/MainLayout.razor
@@ -136,7 +136,17 @@
         <TelegramDownloader.Pages.Modals.ToastNotify></TelegramDownloader.Pages.Modals.ToastNotify>
 
         <article class="content px-4">
-            @Body
+            @if (authResolved)
+            {
+                @Body
+            }
+            else
+            {
+                <div class="d-flex flex-column justify-content-center align-items-center" style="min-height: 60vh; gap: 12px;">
+                    <Spinner Type="SpinnerType.Border" />
+                    <span class="text-muted">Checking session...</span>
+                </div>
+            }
         </article>
 
         <TelegramDownloader.Pages.Modals.AudioPlayerModal @ref="audioPlayer" />
@@ -333,6 +343,7 @@
     private VersionBadge versionBadge { get; set; }
     private bool active { get; set; } = true;
     private bool sidebarCollapsed { get; set; } = false;
+    private bool authResolved { get; set; } = false;
     private bool navMenuCollapsed { get; set; } = true;
     private bool showVersionModal { get; set; } = false;
     private static MainLayout? _instance;
@@ -514,21 +525,6 @@
         }
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            try
-            {
-                if (!ts.checkUserLogin()) NavManager.NavigateTo("/", true);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
-        }
-    }
-
     protected override async Task OnInitializedAsync()
     {
         // Check if setup is complete using async method to avoid deadlock
@@ -538,6 +534,34 @@
             NavManager.NavigateTo("/setup", forceLoad: true);
             return;
         }
+
+        // Auth guard: resolve the session BEFORE any page content renders (the
+        // page body is gated on authResolved, so page components are not even
+        // instantiated until this completes). After an app restart the client
+        // exists but the user is not loaded yet, so attempt a silent session
+        // restore first; only bounce to the login page - keeping the requested
+        // URL so login can come back to it - when interactive login is needed.
+        if (!ts.checkUserLogin())
+        {
+            string authType = null;
+            try
+            {
+                authType = await ts.checkAuth(null);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            if (authType != "ok")
+            {
+                string returnUrl = new Uri(NavManager.Uri).PathAndQuery;
+                NavManager.NavigateTo(string.IsNullOrEmpty(returnUrl) || returnUrl == "/"
+                    ? "/"
+                    : $"/?returnUrl={Uri.EscapeDataString(returnUrl)}", forceLoad: true);
+                return;
+            }
+        }
+        authResolved = true;
 
         await checkWorkingTasks();
         tis.TaskEventChanged += eventChangedWorkingTasks;


### PR DESCRIPTION
## Problem
Two related issues after an app restart (client initialized but user not yet loaded):

1. Pages rendered their content first, and only after the first render did `MainLayout` notice the missing user and hard-redirect to the login page — a visible flash of half-loaded content.
2. The originally requested URL was lost: the login page always navigated to `/fetchdata` after authenticating, regardless of where the user was heading.

## Changes
**Auth guard, before anything renders** ([MainLayout.razor](TelegramDownloader/Shared/MainLayout.razor), [ConfigLayout.razor](TelegramDownloader/Shared/ConfigLayout.razor)):
- The check now runs in `OnInitializedAsync` — first thing after the setup check — and the layout body is gated behind it, so page components are **not even instantiated** until the session is resolved (a spinner with "Checking session..." shows meanwhile).
- If the user is not loaded, a **silent session restore** is attempted first (`checkAuth(null)`, the same call the login page makes — it connects and completes the login from the saved session). If it succeeds, the requested page renders directly, with no bounce through the login page at all.
- Only when interactive login is really needed does the guard redirect to `/`, passing the current URL as `?returnUrl=...`.
- The old `OnAfterRenderAsync` check (the source of the flash) is removed.

**Return to the requested page** ([Index.razor](TelegramDownloader/Pages/Index.razor)):
- After a successful login, the page navigates to the validated `returnUrl` instead of the hardcoded `/fetchdata` (which remains the fallback).
- Only local paths are accepted (`/...`, not `//...`, not `/`), avoiding open-redirect issues.

## Flow after this PR
- Restart + visit `/downloads?tab=uploads` → spinner → silent restore succeeds → the downloads page renders. No login page, no flash, no lost URL.
- Restart with an expired/missing session + visit `/downloads` → spinner → redirect to `/?returnUrl=%2Fdownloads` → user logs in → lands back on `/downloads`.
