### PR TITLE
feat: QR code login option in the web login page

### DIFF
--- a/TelegramDownloader/Data/ITelegramService.cs
+++ b/TelegramDownloader/Data/ITelegramService.cs
@@ -19,6 +19,7 @@ namespace TelegramDownloader.Data
         Task<InvitationInfo?> getInvitationHash(long id);
         Task joinChatInvitationHash(string? hash);
         Task<User> CallQrGenerator(Action<string> func, CancellationToken ct, bool logoutFirst = false);
+        void ProvideQrLoginPassword(string password);
         Task<string> DownloadFile(ChatMessages message, string fileName = null, string folder = null, DownloadModel model = null, bool shouldAddToList = false);
         Task<Byte[]> DownloadFileStream(Message message, long offset, int limit);
         IAsyncEnumerable<byte[]> DownloadFileStreamChunks(Message message, long offset, long limit, CancellationToken ct = default);

--- a/TelegramDownloader/Data/TelegramService.cs
+++ b/TelegramDownloader/Data/TelegramService.cs
@@ -173,7 +173,20 @@ namespace TelegramDownloader.Data
             {
                 _logger.LogDebug(ex, "Could not snapshot the session file");
             }
-            client = new WTelegram.Client(Convert.ToInt32(GeneralConfigStatic.tlconfig?.api_id ?? Environment.GetEnvironmentVariable("api_id")), GeneralConfigStatic.tlconfig?.hash_id ?? Environment.GetEnvironmentVariable("hash_id"), UserService.USERDATAFOLDER + "/WTelegram.session");
+            string apiId = GeneralConfigStatic.tlconfig?.api_id ?? Environment.GetEnvironmentVariable("api_id");
+            string apiHash = GeneralConfigStatic.tlconfig?.hash_id ?? Environment.GetEnvironmentVariable("hash_id");
+            // Custom config callback instead of the convenience constructor: the
+            // QR login flow (LoginWithQRCode) asks for the 2FA password through
+            // Config("password") - with the default config that prompt would go
+            // to the console. Route it to the web UI instead.
+            client = new WTelegram.Client(what => what switch
+            {
+                "api_id" => apiId,
+                "api_hash" => apiHash,
+                "session_pathname" => UserService.USERDATAFOLDER + "/WTelegram.session",
+                "password" => RequestLoginPassword(),
+                _ => null
+            });
             ApplyConfiguredParallelTransfers(client);
             if (GeneralConfigStatic.config.ShouldShowLogInTerminal)
             {
@@ -585,9 +598,41 @@ namespace TelegramDownloader.Data
 
         #endregion
 
+        // 2FA password bridge for the QR login flow: WTelegram asks for the
+        // password via Config("password") on a background task; the UI is
+        // notified through QrPasswordNeeded and supplies the value with
+        // ProvideQrLoginPassword, unblocking the pending request.
+        private static TaskCompletionSource<string> qrPasswordRequest;
+        public static event EventHandler QrPasswordNeeded;
+
+        private static string RequestLoginPassword()
+        {
+            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            qrPasswordRequest = tcs;
+            try
+            {
+                QrPasswordNeeded?.Invoke(null, EventArgs.Empty);
+            }
+            catch (Exception)
+            {
+            }
+            // Blocks the QR login background task, never the UI thread.
+            if (!tcs.Task.Wait(TimeSpan.FromMinutes(5)))
+                throw new TimeoutException("2FA password was not provided in time");
+            return tcs.Task.Result;
+        }
+
+        public void ProvideQrLoginPassword(string password)
+        {
+            qrPasswordRequest?.TrySetResult(password);
+        }
+
         public async Task<User> CallQrGenerator(Action<string> func, CancellationToken ct, bool logoutFirst = false)
         {
-            return await client.LoginWithQRCode(func, logoutFirst: logoutFirst, ct: ct);
+            User user = await client.LoginWithQRCode(func, logoutFirst: logoutFirst, ct: ct);
+            if (user != null)
+                await CompleteLogin();
+            return user;
         }
 
         public async Task<User> GetUser()
@@ -632,6 +677,16 @@ namespace TelegramDownloader.Data
                         return "pass"; // if user has enabled 2FA
                     default: break;
                 }
+            return await CompleteLogin();
+        }
+
+        /// <summary>
+        /// Post-login initialization shared by the interactive login flow and the
+        /// QR login flow: loads chats, resolves premium limits and notifies
+        /// subscribers.
+        /// </summary>
+        private async Task<string> CompleteLogin()
+        {
             await getAllChats();
             SetSplitSizeGB();
             if (client.User.flags.HasFlag(User.Flags.premium))
@@ -696,8 +751,20 @@ namespace TelegramDownloader.Data
                 }
                 else
                 {
-                    _logger.LogInformation("No saved user data found, requesting phone");
-                    return "phone";
+                    // No saved phone (e.g. the session was created via QR login):
+                    // try to restore the session directly - Login(null) completes
+                    // silently when the stored session is still authorized and
+                    // returns the "phone" step otherwise.
+                    try
+                    {
+                        _logger.LogInformation("No saved user data found, attempting session restore");
+                        return await DoLogin(null) ?? "phone";
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Session restore without saved user data failed, requesting phone");
+                        return "phone";
+                    }
                 }
 
             }

--- a/TelegramDownloader/Pages/Index.razor
+++ b/TelegramDownloader/Pages/Index.razor
@@ -43,6 +43,10 @@
                     <h1 class="login-title">Two-Factor Auth</h1>
                     <p class="login-subtitle">Enter your 2FA password</p>
                     break;
+                case "qr":
+                    <h1 class="login-title">Scan QR Code</h1>
+                    <p class="login-subtitle">Log in with your phone, no number needed</p>
+                    break;
                 case "ok":
                     <h1 class="login-title">Welcome Back!</h1>
                     <p class="login-subtitle">You are successfully authenticated</p>
@@ -81,6 +85,15 @@
                                        @bind-Value="Model!.value" placeholder="Enter your 2FA password" />
                         </div>
                         break;
+                    case "qr":
+                        <div class="text-center">
+                            <p class="login-subtitle" style="margin-bottom: 0;">
+                                Open Telegram on your phone and go to<br />
+                                <b>Settings &gt; Devices &gt; Link Desktop Device</b>,<br />
+                                then scan this code.
+                            </p>
+                        </div>
+                        break;
                     case "ok":
                         <div class="text-center">
                             <div class="success-badge">
@@ -96,6 +109,12 @@
                     {
                         <button class="btn-danger-custom" @onclick="Salir" type="button">
                             <i class="bi bi-box-arrow-right"></i> Disconnect
+                        </button>
+                    }
+                    else if (Model.type == "qr")
+                    {
+                        <button class="btn-secondary-custom" type="button" @onclick="CancelQrLogin">
+                            <i class="bi bi-arrow-left"></i> Back to phone login
                         </button>
                     }
                     else
@@ -118,6 +137,12 @@
                                 Cancel
                             </button>
                         }
+                    }
+                    @if (Model.type == "phone")
+                    {
+                        <button class="btn-secondary-custom" type="button" @onclick="StartQrLogin">
+                            <i class="bi bi-qr-code-scan"></i> Log in with QR code
+                        </button>
                     }
                 </div>
 
@@ -248,8 +273,75 @@
         }
     }
 
+    private bool qrMode = false;
+
+    private async Task StartQrLogin()
+    {
+        qrMode = true;
+        imageString = null;
+        Model.type = "qr";
+        source?.Cancel();
+        source = new CancellationTokenSource();
+        StateHasChanged();
+        TelegramService.QrPasswordNeeded += OnQrPasswordNeeded;
+        try
+        {
+            var user = await ts.CallQrGenerator(url => { _ = InvokeAsync(() => GenerateQR(url)); }, source.Token);
+            if (user != null)
+            {
+                imageString = null;
+                Model.type = "ok";
+                await InvokeAsync(StateHasChanged);
+                await isLogin();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // User went back to phone login or left the page
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"QR login failed: {ex.Message}");
+            qrMode = false;
+            imageString = null;
+            Model.type = "phone";
+            await InvokeAsync(StateHasChanged);
+        }
+        finally
+        {
+            TelegramService.QrPasswordNeeded -= OnQrPasswordNeeded;
+        }
+    }
+
+    private void OnQrPasswordNeeded(object sender, System.EventArgs e)
+    {
+        // The QR was accepted on the phone but the account has 2FA: switch the
+        // form to the password step; Submit routes the value back to the
+        // pending QR login.
+        imageString = null;
+        Model.value = "";
+        Model.type = "pass";
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void CancelQrLogin()
+    {
+        qrMode = false;
+        imageString = null;
+        source?.Cancel();
+        Model.type = "phone";
+    }
+
     private async void Submit()
     {
+        if (qrMode && Model.type == "pass")
+        {
+            // 2FA password for a QR login: hand it to the waiting login task,
+            // which finishes the flow and navigates from StartQrLogin.
+            ts.ProvideQrLoginPassword(Model.value);
+            Model.value = "";
+            return;
+        }
         if (Model.type == "phone")
         {
             var phone = await JSRuntime.InvokeAsync<string>("getNumber");
@@ -308,6 +400,7 @@
 
     public void Dispose()
     {
+        TelegramService.QrPasswordNeeded -= OnQrPasswordNeeded;
         if (source != null)
         {
             if (source.Token.CanBeCanceled)


### PR DESCRIPTION
## Problem
QR login seemed to work only when driving WTelegramClient from a terminal. Investigation confirmed it:

- The plumbing existed (`CallQrGenerator` wrapping `LoginWithQRCode`, QR rendering helpers in `Index.razor`) but **nothing invoked it** — dead code.
- Even if invoked, it could not work from the web for 2FA accounts: `LoginWithQRCode` requests the password through `Config("password")` (verified in the library source), and with the convenience constructor that prompt goes to the **console**. That is why it only appeared to work from CMD.

## Changes
**2FA password bridge** ([TelegramService.cs](TelegramDownloader/Data/TelegramService.cs)):
- The main client is now built with a custom config callback; the `"password"` request is routed to the web UI: a static `QrPasswordNeeded` event notifies the login page, and the value returns through `ProvideQrLoginPassword` into a `TaskCompletionSource` the login task blocks on (5-minute timeout, background thread only — never the UI).
- `DoLogin`'s post-login tail (chats, premium limits, `OnUserLoggedIn`) is extracted into `CompleteLogin()` and reused by the QR flow, so a QR login initializes the app exactly like a phone login.

**Login page** ([Index.razor](TelegramDownloader/Pages/Index.razor)):
- New "Log in with QR code" button on the phone step → shows the `tg://login` QR (re-rendered automatically when the library rotates the token on expiry) with instructions (Settings > Devices > Link Desktop Device) and a "Back to phone login" button.
- If the account has 2FA, after scanning the form switches to the existing password step; submitting routes the password to the pending QR login.
- On success, the standard navigation flow runs (compatible with the `returnUrl` mechanism from #109 if merged).

**QR sessions survive restarts**:
- `checkAuth` bounced straight to the phone step when no saved user data file existed — which is always the case for QR logins (there is no phone number to save). It now attempts a silent session restore via `DoLogin(null)` first, falling back to the phone step only if the session is really dead.

## Testing notes
1. Log out, open the login page → "Log in with QR code" → scan from the phone → should land logged in (with 2FA: the password step appears after scanning).
2. Restart the app after a QR login → session should restore silently instead of asking for a phone number.
