### PR TITLE
feat: live refresh in the download/upload/task info modals

### DIFF
--- a/TelegramDownloader/Pages/Modals/InfoModals/DownloadFileInfoModal.razor
+++ b/TelegramDownloader/Pages/Modals/InfoModals/DownloadFileInfoModal.razor
@@ -1,5 +1,8 @@
 @using TelegramDownloader.Models
 @using TelegramDownloader.Services
+@implements IDisposable
+
+@inject TransactionInfoService tis
 
 <style>
     .download-info-modal-overlay {
@@ -416,6 +419,11 @@
         this.downloadModel = downloadModel;
         if (this.downloadModel != null)
         {
+            // Live refresh while the modal is open: the model reference is live,
+            // so re-rendering on the aggregated (throttled) transactions event
+            // keeps progress, state, duration and speed up to date.
+            tis.TransactionsChanged -= OnTransactionsChanged;
+            tis.TransactionsChanged += OnTransactionsChanged;
             isVisible = true;
             StateHasChanged();
         }
@@ -423,6 +431,7 @@
 
     private async Task HideModal()
     {
+        tis.TransactionsChanged -= OnTransactionsChanged;
         isVisible = false;
         StateHasChanged();
 
@@ -430,6 +439,21 @@
         {
             await OnClose.InvokeAsync();
         }
+    }
+
+    private async void OnTransactionsChanged(object sender, System.EventArgs e)
+    {
+        if (!isVisible) return;
+        try
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+        catch { }
+    }
+
+    public void Dispose()
+    {
+        tis.TransactionsChanged -= OnTransactionsChanged;
     }
 
     private async Task OnOverlayClick()

--- a/TelegramDownloader/Pages/Modals/InfoModals/TaskInfoModal.razor
+++ b/TelegramDownloader/Pages/Modals/InfoModals/TaskInfoModal.razor
@@ -1,5 +1,8 @@
 @using TelegramDownloader.Models
 @using TelegramDownloader.Services
+@implements IDisposable
+
+@inject TransactionInfoService tis
 
 <style>
     .task-info-modal-overlay {
@@ -465,6 +468,11 @@
         this.taskModel = taskModel;
         if (this.taskModel != null)
         {
+            // Live refresh while the modal is open: the model reference is live,
+            // so re-rendering on the aggregated (throttled) transactions event
+            // keeps progress, state, duration and file counters up to date.
+            tis.TransactionsChanged -= OnTransactionsChanged;
+            tis.TransactionsChanged += OnTransactionsChanged;
             isVisible = true;
             StateHasChanged();
         }
@@ -472,6 +480,7 @@
 
     private async Task HideModal()
     {
+        tis.TransactionsChanged -= OnTransactionsChanged;
         isVisible = false;
         StateHasChanged();
 
@@ -479,6 +488,21 @@
         {
             await OnClose.InvokeAsync();
         }
+    }
+
+    private async void OnTransactionsChanged(object sender, System.EventArgs e)
+    {
+        if (!isVisible) return;
+        try
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+        catch { }
+    }
+
+    public void Dispose()
+    {
+        tis.TransactionsChanged -= OnTransactionsChanged;
     }
 
     private async Task OnOverlayClick()

--- a/TelegramDownloader/Pages/Modals/InfoModals/UploadFileInfoModal.razor
+++ b/TelegramDownloader/Pages/Modals/InfoModals/UploadFileInfoModal.razor
@@ -1,5 +1,8 @@
 @using TelegramDownloader.Models
 @using TelegramDownloader.Services
+@implements IDisposable
+
+@inject TransactionInfoService tis
 
 <style>
     .upload-modal-overlay {
@@ -422,6 +425,11 @@
         this.uploadModel = uploadModel;
         if (this.uploadModel != null)
         {
+            // Live refresh while the modal is open: the model reference is live,
+            // so re-rendering on the aggregated (throttled) transactions event
+            // keeps progress, state, duration and speed up to date.
+            tis.TransactionsChanged -= OnTransactionsChanged;
+            tis.TransactionsChanged += OnTransactionsChanged;
             isVisible = true;
             StateHasChanged();
         }
@@ -429,6 +437,7 @@
 
     private async Task HideModal()
     {
+        tis.TransactionsChanged -= OnTransactionsChanged;
         isVisible = false;
         StateHasChanged();
 
@@ -436,6 +445,21 @@
         {
             await OnClose.InvokeAsync();
         }
+    }
+
+    private async void OnTransactionsChanged(object sender, System.EventArgs e)
+    {
+        if (!isVisible) return;
+        try
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+        catch { }
+    }
+
+    public void Dispose()
+    {
+        tis.TransactionsChanged -= OnTransactionsChanged;
     }
 
     private async Task OnOverlayClick()


### PR DESCRIPTION
## Problem
The info modals (DownloadFileInfoModal, UploadFileInfoModal, TaskInfoModal) hold a live reference to their model but only render the snapshot taken when opened: progress, state, transferred bytes, duration and average speed stay frozen until the modal is closed and reopened.

## Changes
Each modal now subscribes to the aggregated, throttled `TransactionsChanged` event (introduced in #98) **only while it is visible**: subscribed in `ShowModal`, unsubscribed in `HideModal` and `Dispose`, re-rendering via `InvokeAsync(StateHasChanged)` — the same pattern the transfer tables use. Since the model reference is live, a re-render is all that is needed; updates arrive at most every ~250ms thanks to the service-side throttle.

This covers progress %, transferred/total bytes, state badge, duration, average speed and (in the task modal) the per-file counters, all updating in real time while the modal is open.